### PR TITLE
feat: allow direct submission of extrinsic

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This SDK is split into two main parts:
 
 - **[`src/config`](./src/config/)**: Contains the loader to read the config file when connecting to chain
 - **[`src/extrinsic`](./src/extrinsic/)**: Wrapper around GSRPC so that extrinsic can be signed with avail specific AppID extension
-- **[src/header`](./src/header/)**: Includes the custom header for avail with added extension field and its custom enum decoding 
+- **[`src/header`](./src/header/)**: Includes the custom header for avail with added extension field and its custom enum decoding 
 - **[`src/rpc`](./src/rpc/)**: Wraper around GSRPC block specific rpc calls inorder to accustom the custom header field for avail. Also contains the structures for kate related calls.
 - **[`src/sdk`](./src/sdk/)**: Contains all interfaces related to the SDK, representing the opinionated part of Avail-go-sdk.
 - **[`src/sdk/call`](./src/sdk/call/)**: Contains the kate related RPC calls

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -2,6 +2,8 @@ module examples
 
 go 1.21.0
 
+replace github.com/availproject/avail-go-sdk => ../
+
 require (
 	github.com/availproject/avail-go-sdk v0.1.2
 	github.com/vedhavyas/go-subkey v1.0.4

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -2,8 +2,6 @@ github.com/ChainSafe/go-schnorrkel v1.0.0 h1:3aDA67lAykLaG1y3AOjs88dMxC88PgUuHRr
 github.com/ChainSafe/go-schnorrkel v1.0.0/go.mod h1:dpzHYVxLZcp8pjlV+O+UR8K0Hp/z7vcchBSbMBEhCw4=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 h1:fLjPD/aNc3UIOA6tDi6QXUemppXK3P9BI7mr2hd6gx8=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/availproject/avail-go-sdk v0.1.2 h1:DZLuEFmLlMHyqRcAaIkJumiMTMYVBqEWXDemSuCF4Xo=
-github.com/availproject/avail-go-sdk v0.1.2/go.mod h1:2LX1D4jRJhLAozmUF8Fzrh8FUA0WhjT1VpUykZsUqDM=
 github.com/btcsuite/btcd v0.22.0-beta h1:LTDpDKUM5EeOFBPM8IXpinEcmZ6FWfNZbE3lfrfdnWo=
 github.com/btcsuite/btcd/btcec/v2 v2.2.0 h1:fzn1qaOt32TuLjFlkzYSsBC35Q3KUjT1SwPxiMSCF5k=
 github.com/btcsuite/btcd/btcec/v2 v2.2.0/go.mod h1:U7MHm051Al6XmscBQ0BoNydpOTsFAn707034b5nY8zU=

--- a/examples/submit_extrinsic/main.go
+++ b/examples/submit_extrinsic/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"github.com/availproject/avail-go-sdk/src/config"
+	"github.com/availproject/avail-go-sdk/src/sdk"
+	"github.com/availproject/avail-go-sdk/src/sdk/tx"
+
+	"fmt"
+)
+
+func main() {
+	config, err := config.LoadConfig()
+	if err != nil {
+		fmt.Printf("cannot load config:%v", err)
+	}
+	api, err := sdk.NewSDK(config.ApiURL)
+	if err != nil {
+		fmt.Printf("cannot create api:%v", err)
+	}
+
+	appID := 0
+
+	// if app id is greater than 0 then it must be created before submitting data
+	if config.AppID != 0 {
+		appID = config.AppID
+	}
+
+	keyringPair, err := sdk.KeyringFromSeed(config.Seed)
+	if err != nil {
+		panic(fmt.Sprintf("cannot create KeyPair:%v", err))
+	}
+
+	// create extrinsic
+	fmt.Println("Creating extrinsic ...")
+	ext, err := sdk.CreateExtrinsic(api, "DataAvailability.submit_data", keyringPair, appID, "my happy data")
+	if err != nil {
+		fmt.Printf("cannot create extrinsic:%v", err)
+	}
+	fmt.Println("Extrinsic created successfully for method: DataAvailability.submit_data")
+
+	// submit extrinsic
+	fmt.Println("Submitting extrinsic ...")
+	WaitFor := sdk.BlockInclusion
+	BlockHash, txHash, err := tx.SubmitExtrinsic(api, ext, WaitFor)
+	if err != nil {
+		fmt.Printf("cannot submit extrinsic:%v", err)
+	}
+	fmt.Printf("\nExtrinsic submitted successfully with block hash: %v\n and ext hash:%v", BlockHash.Hex(), txHash.Hex())
+}

--- a/examples/submit_extrinsic/main.go
+++ b/examples/submit_extrinsic/main.go
@@ -36,7 +36,11 @@ func main() {
 	if err != nil {
 		fmt.Printf("cannot create extrinsic:%v", err)
 	}
-	fmt.Println("Extrinsic created successfully for method: DataAvailability.submit_data")
+	txHash, err := ext.TxHash()
+	if err != nil {
+		fmt.Printf("cannot get extrinsic tx hash:%v", err)
+	}
+	fmt.Printf("\nExtrinsic created successfully: %v\n", txHash.Hex())
 
 	// submit extrinsic
 	fmt.Println("Submitting extrinsic ...")
@@ -45,5 +49,5 @@ func main() {
 	if err != nil {
 		fmt.Printf("cannot submit extrinsic:%v", err)
 	}
-	fmt.Printf("\nExtrinsic submitted successfully with block hash: %v\n and ext hash:%v", BlockHash.Hex(), txHash.Hex())
+	fmt.Printf("\nExtrinsic submitted successfully with block hash: %v\n and ext hash:%v\n", BlockHash.Hex(), txHash.Hex())
 }

--- a/src/extrinsic/extrinsic.go
+++ b/src/extrinsic/extrinsic.go
@@ -2,6 +2,7 @@ package extrinsic
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -11,6 +12,8 @@ import (
 	"github.com/centrifuge/go-substrate-rpc-client/v4/signature"
 	"github.com/centrifuge/go-substrate-rpc-client/v4/types"
 	"github.com/centrifuge/go-substrate-rpc-client/v4/types/codec"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"golang.org/x/crypto/blake2b"
 )
 
 type SignatureOptions struct {
@@ -259,4 +262,23 @@ func (e Extrinsic) Encode(encoder scale.Encoder) error {
 	}
 
 	return nil
+}
+
+func (e *Extrinsic) TxHash() (types.Hash, error) {
+	enc, err := codec.EncodeToHex(e)
+	if err != nil {
+		return types.Hash{}, err
+	}
+	cleanedHexString := strings.TrimPrefix(enc, "0x")
+	bytes, err := hex.DecodeString(cleanedHexString)
+	if err != nil {
+		return types.Hash{}, err
+	}
+	hash := blake2b.Sum256(bytes)
+	ext_z := hexutil.Encode(hash[:])
+	hash, err = types.NewHashFromHexString(ext_z)
+	if err != nil {
+		return types.Hash{}, err
+	}
+	return hash, nil
 }

--- a/src/sdk/callExtrinsic.go
+++ b/src/sdk/callExtrinsic.go
@@ -1,10 +1,8 @@
 package sdk
 
 import (
-	"encoding/hex"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/availproject/avail-go-sdk/src/extrinsic"
@@ -12,8 +10,6 @@ import (
 
 	"github.com/centrifuge/go-substrate-rpc-client/v4/signature"
 	"github.com/centrifuge/go-substrate-rpc-client/v4/types"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"golang.org/x/crypto/blake2b"
 )
 
 func CreateExtrinsic(api *SubstrateAPI, ext_call string, keyring signature.KeyringPair, AppID int, arg ...interface{}) (extrinsic.Extrinsic, error) {
@@ -75,16 +71,7 @@ func SubmitExtrinsic(api *SubstrateAPI, ext extrinsic.Extrinsic) (types.Hash, er
 
 func SubmitExtrinsicWatch(api *SubstrateAPI, ext extrinsic.Extrinsic, final chan types.Hash, txHash chan types.Hash, WaitForInclusion WaitFor) error {
 	go func() {
-		enc, _ := EncodeToHex(ext)
-
-		cleanedHexString := strings.TrimPrefix(enc, "0x")
-		bytes, err := hex.DecodeString(cleanedHexString)
-		if err != nil {
-			log.Fatal(err)
-		}
-		hash := blake2b.Sum256(bytes)
-		ext_z := hexutil.Encode(hash[:])
-		hash, err = NewHashFromHexString(ext_z)
+		hash, err := ext.TxHash()
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/src/sdk/callExtrinsic.go
+++ b/src/sdk/callExtrinsic.go
@@ -54,15 +54,16 @@ func CreateExtrinsic(api *SubstrateAPI, ext_call string, keyring signature.Keyri
 
 	err = ext.Sign(keyring, options)
 	if err != nil {
-		panic(fmt.Sprintf("cannot sign:%v", err))
+		return extrinsic.Extrinsic{}, fmt.Errorf("cannot sign:%v", err)
 	}
+
 	return ext, nil
 }
 
 func SubmitExtrinsic(api *SubstrateAPI, ext extrinsic.Extrinsic) (types.Hash, error) {
 	hash, err := rpc.SubmitExtrinsic(ext, api.Client)
 	if err != nil {
-		panic(fmt.Sprintf("cannot submit extrinsic:%v", err))
+		return types.Hash{}, fmt.Errorf("cannot submit extrinsic:%v", err)
 	}
 
 	fmt.Printf("Data submitted using APPID: %v \n", ext.Signature.AppID.Int64())
@@ -80,7 +81,7 @@ func SubmitExtrinsicWatch(api *SubstrateAPI, ext extrinsic.Extrinsic, final chan
 
 	sub, err := rpc.SubmitAndWatchExtrinsic(ext, api.Client)
 	if err != nil {
-		panic(fmt.Sprintf("cannot submit extrinsic:%v", err))
+		return fmt.Errorf("cannot submit extrinsic:%v", err)
 	}
 
 	fmt.Printf("Transaction being submitted .... ⏳Waiting for block inclusion..")

--- a/src/sdk/helper.go
+++ b/src/sdk/helper.go
@@ -15,9 +15,7 @@ import (
 	"github.com/centrifuge/go-substrate-rpc-client/v4/signature"
 	"github.com/centrifuge/go-substrate-rpc-client/v4/types"
 	"github.com/centrifuge/go-substrate-rpc-client/v4/types/codec"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/vedhavyas/go-subkey"
-	"golang.org/x/crypto/blake2b"
 )
 
 func ConvertMultiAddress(receiver string) (types.MultiAddress, error) {
@@ -259,15 +257,11 @@ func GetData(hash types.Hash, api *SubstrateAPI, txHash types.Hash) error {
 
 		// these values below are specific indexes only for data submission, differs with each extrinsic
 		if ext.IsSigned() && ext.Method.CallIndex.SectionIndex == 29 && ext.Method.CallIndex.MethodIndex == 1 {
-			enc, _ := EncodeToHex(ext)
-			cleanedHexString := strings.TrimPrefix(enc, "0x")
-			bytes, err := hex.DecodeString(cleanedHexString)
+			extTxHash, err := ext.TxHash()
 			if err != nil {
 				log.Fatal(err)
 			}
-			hash := blake2b.Sum256(bytes)
-			txHashDecoded := hexutil.Encode(hash[:])
-			if txHashDecoded == txHash.Hex() {
+			if extTxHash.Hex() == txHash.Hex() {
 				arg := ext.Method.Args
 				str := string(arg)
 				slice := str[1:]

--- a/src/sdk/tx/transactions.go
+++ b/src/sdk/tx/transactions.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"strconv"
 
+	"github.com/availproject/avail-go-sdk/src/extrinsic"
 	"github.com/availproject/avail-go-sdk/src/sdk"
 	"github.com/availproject/avail-go-sdk/src/sdk/types"
 
@@ -464,6 +465,25 @@ func TransferAll(api *sdk.SubstrateAPI, seed string, WaitForInclusion sdk.WaitFo
 			return
 		}
 		fmt.Println("Transaction submitted successfully")
+	}()
+	blockHash := <-BlockHashCh2
+	txHash := <-txHashCh2
+	return blockHash, txHash, nil
+}
+
+func SubmitExtrinsic(api *sdk.SubstrateAPI, ext extrinsic.Extrinsic, WaitForInclusion sdk.WaitFor) (types.Hash, types.Hash, error) {
+	BlockHashCh2 := make(chan types.Hash)
+	txHashCh2 := make(chan types.Hash)
+
+	go func() {
+		err := sdk.SubmitExtrinsicWatch(api, ext, BlockHashCh2, txHashCh2, WaitForInclusion)
+		if err != nil {
+			fmt.Printf("cannot submit extrinsic: %v", err)
+			close(BlockHashCh2)
+			close(txHashCh2)
+			return
+		}
+		fmt.Println("Extrinsic submitted successfully")
 	}()
 	blockHash := <-BlockHashCh2
 	txHash := <-txHashCh2


### PR DESCRIPTION
#### Issue Description

Currently, there exists the `sdk.CreateExtrinsic` public method that lets a user of this pkg create an extrinsic. However, no public method exists for directly submitting an already created extrinsic. This PR addresses this by adding public methods like `sdk.SubmitExtrinsic` and `tx.SubmitExtrinsic`.

#### Changes Summary

- Lots of refactor/cleanup in `sdk/callExtrinsic.go` file.
- Adds 2 new public methods `SubmitExtrinsic` and `SubmitExtrinsicWatch` in `sdk` package.
- Adds 1 new public method `SubmitExtrinsic` in `tx` package.
- Adds new example `submit_extrinsic` to showcase the above. 