### PR TITLE
Refactor: use idiomatic Go receiver names instead of `this`

### DIFF
--- a/examples/enum.go
+++ b/examples/enum.go
@@ -12,8 +12,8 @@ type SimpleEnum struct {
 	VariantIndex uint8
 }
 
-func (this SimpleEnum) ToString() string {
-	switch this.VariantIndex {
+func (se SimpleEnum) ToString() string {
+	switch se.VariantIndex {
 	case 0:
 		return "Nothing"
 	case 1:
@@ -37,64 +37,64 @@ type ComplexEnum struct {
 	Year         prim.Option[uint32]
 }
 
-func (this ComplexEnum) ToString() string {
-	switch this.VariantIndex {
+func (se ComplexEnum) ToString() string {
+	switch se.VariantIndex {
 	case 0:
 		return "Nothing"
 	case 1:
-		return fmt.Sprintf("Set: %v", this.Day.Unwrap())
+		return fmt.Sprintf("Set: %v", se.Day.Unwrap())
 	case 2:
-		return fmt.Sprintf("Set: %v", this.Month.Unwrap())
+		return fmt.Sprintf("Set: %v", se.Month.Unwrap())
 	case 3:
-		return fmt.Sprintf("Set: %v", this.Year.Unwrap())
+		return fmt.Sprintf("Set: %v", se.Year.Unwrap())
 	default:
 		panic("Unknown ComplexEnum Variant Index")
 	}
 }
 
-func (this *ComplexEnum) EncodeTo(dest *string) {
-	prim.Encoder.EncodeTo(this.VariantIndex, dest)
+func (se *ComplexEnum) EncodeTo(dest *string) {
+	prim.Encoder.EncodeTo(se.VariantIndex, dest)
 
-	if this.Day.IsSome() {
-		prim.Encoder.EncodeTo(this.Day.Unwrap(), dest)
+	if se.Day.IsSome() {
+		prim.Encoder.EncodeTo(se.Day.Unwrap(), dest)
 	}
 
-	if this.Month.IsSome() {
-		prim.Encoder.EncodeTo(this.Month.Unwrap(), dest)
+	if se.Month.IsSome() {
+		prim.Encoder.EncodeTo(se.Month.Unwrap(), dest)
 	}
 
-	if this.Year.IsSome() {
-		prim.Encoder.EncodeTo(this.Year.Unwrap(), dest)
+	if se.Year.IsSome() {
+		prim.Encoder.EncodeTo(se.Year.Unwrap(), dest)
 	}
 }
 
-func (this *ComplexEnum) Decode(decoder *prim.Decoder) error {
-	*this = ComplexEnum{}
+func (se *ComplexEnum) Decode(decoder *prim.Decoder) error {
+	*se = ComplexEnum{}
 
-	if err := decoder.Decode(&this.VariantIndex); err != nil {
+	if err := decoder.Decode(&se.VariantIndex); err != nil {
 		return err
 	}
 
-	switch this.VariantIndex {
+	switch se.VariantIndex {
 	case 0:
 	case 1:
 		var t uint16
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Day.Set(t)
+		se.Day.Set(t)
 	case 2:
 		var t uint8
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Month.Set(t)
+		se.Month.Set(t)
 	case 3:
 		var t uint32
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Year.Set(t)
+		se.Year.Set(t)
 	default:
 		return errors.New("Unknown ComplexEnum Variant Index while Decoding")
 	}

--- a/examples/transaction_custom.go
+++ b/examples/transaction_custom.go
@@ -2,6 +2,7 @@ package examples
 
 import (
 	"fmt"
+
 	"github.com/availproject/avail-go-sdk/metadata/pallets"
 
 	daPallet "github.com/availproject/avail-go-sdk/metadata/pallets/data_availability"
@@ -12,19 +13,19 @@ type CustomTransaction struct {
 	Value []byte
 }
 
-func (this CustomTransaction) PalletName() string {
+func (ct CustomTransaction) PalletName() string {
 	return "DataAvailability"
 }
 
-func (this CustomTransaction) PalletIndex() uint8 {
+func (ct CustomTransaction) PalletIndex() uint8 {
 	return 29
 }
 
-func (this CustomTransaction) CallName() string {
+func (ct CustomTransaction) CallName() string {
 	return "submit_data"
 }
 
-func (this CustomTransaction) CallIndex() uint8 {
+func (ct CustomTransaction) CallIndex() uint8 {
 	return 1
 }
 

--- a/metadata/pallets/balances/calls.go
+++ b/metadata/pallets/balances/calls.go
@@ -19,19 +19,19 @@ type CallTransferAlowDeath struct {
 	Value uint128.Uint128 `scale:"compact"`
 }
 
-func (this CallTransferAlowDeath) PalletIndex() uint8 {
+func (ctad CallTransferAlowDeath) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallTransferAlowDeath) PalletName() string {
+func (ctad CallTransferAlowDeath) PalletName() string {
 	return PalletName
 }
 
-func (this CallTransferAlowDeath) CallIndex() uint8 {
+func (ctad CallTransferAlowDeath) CallIndex() uint8 {
 	return 0
 }
 
-func (this CallTransferAlowDeath) CallName() string {
+func (ctad CallTransferAlowDeath) CallName() string {
 	return "transfer_allow_death"
 }
 
@@ -43,19 +43,19 @@ type CallForceTransfer struct {
 	Value  metadata.Balance `scale:"compact"`
 }
 
-func (this CallForceTransfer) PalletIndex() uint8 {
+func (cft CallForceTransfer) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallForceTransfer) PalletName() string {
+func (cft CallForceTransfer) PalletName() string {
 	return PalletName
 }
 
-func (this CallForceTransfer) CallIndex() uint8 {
+func (cft CallForceTransfer) CallIndex() uint8 {
 	return 2
 }
 
-func (this CallForceTransfer) CallName() string {
+func (cft CallForceTransfer) CallName() string {
 	return "force_transfer"
 }
 
@@ -66,19 +66,19 @@ type CallTransferKeepAlive struct {
 	Value metadata.Balance `scale:"compact"`
 }
 
-func (this CallTransferKeepAlive) PalletIndex() uint8 {
+func (ctka CallTransferKeepAlive) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallTransferKeepAlive) PalletName() string {
+func (ctka CallTransferKeepAlive) PalletName() string {
 	return PalletName
 }
 
-func (this CallTransferKeepAlive) CallIndex() uint8 {
+func (ctka CallTransferKeepAlive) CallIndex() uint8 {
 	return 3
 }
 
-func (this CallTransferKeepAlive) CallName() string {
+func (ctka CallTransferKeepAlive) CallName() string {
 	return "transfer_keep_alive"
 }
 
@@ -92,18 +92,18 @@ type CallTransferAll struct {
 	KeepAlive bool
 }
 
-func (this CallTransferAll) PalletIndex() uint8 {
+func (cta CallTransferAll) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallTransferAll) PalletName() string {
+func (cta CallTransferAll) PalletName() string {
 	return PalletName
 }
 
-func (this CallTransferAll) CallIndex() uint8 {
+func (cta CallTransferAll) CallIndex() uint8 {
 	return 4
 }
 
-func (this CallTransferAll) CallName() string {
+func (cta CallTransferAll) CallName() string {
 	return "transfer_all"
 }

--- a/metadata/pallets/balances/events.go
+++ b/metadata/pallets/balances/events.go
@@ -11,19 +11,19 @@ type EventEndowed struct {
 	FreeBalance metadata.Balance
 }
 
-func (this EventEndowed) PalletIndex() uint8 {
+func (ee EventEndowed) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventEndowed) PalletName() string {
+func (ee EventEndowed) PalletName() string {
 	return PalletName
 }
 
-func (this EventEndowed) EventIndex() uint8 {
+func (ee EventEndowed) EventIndex() uint8 {
 	return 0
 }
 
-func (this EventEndowed) EventName() string {
+func (ee EventEndowed) EventName() string {
 	return "Endowed"
 }
 
@@ -33,19 +33,19 @@ type EventDustLost struct {
 	Amount  metadata.Balance
 }
 
-func (this EventDustLost) PalletIndex() uint8 {
+func (edl EventDustLost) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventDustLost) PalletName() string {
+func (edl EventDustLost) PalletName() string {
 	return PalletName
 }
 
-func (this EventDustLost) EventIndex() uint8 {
+func (edl EventDustLost) EventIndex() uint8 {
 	return 1
 }
 
-func (this EventDustLost) EventName() string {
+func (edl EventDustLost) EventName() string {
 	return "DustLost"
 }
 
@@ -56,19 +56,19 @@ type EventTransfer struct {
 	Amount metadata.Balance
 }
 
-func (this EventTransfer) PalletIndex() uint8 {
+func (et EventTransfer) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventTransfer) PalletName() string {
+func (et EventTransfer) PalletName() string {
 	return PalletName
 }
 
-func (this EventTransfer) EventIndex() uint8 {
+func (et EventTransfer) EventIndex() uint8 {
 	return 2
 }
 
-func (this EventTransfer) EventName() string {
+func (et EventTransfer) EventName() string {
 	return "Transfer"
 }
 
@@ -78,19 +78,19 @@ type EventDeposit struct {
 	Amount metadata.Balance
 }
 
-func (this EventDeposit) PalletIndex() uint8 {
+func (ed EventDeposit) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventDeposit) PalletName() string {
+func (ed EventDeposit) PalletName() string {
 	return PalletName
 }
 
-func (this EventDeposit) EventIndex() uint8 {
+func (ed EventDeposit) EventIndex() uint8 {
 	return 7
 }
 
-func (this EventDeposit) EventName() string {
+func (ed EventDeposit) EventName() string {
 	return "Deposit"
 }
 
@@ -100,18 +100,18 @@ type EventWithdraw struct {
 	Amount metadata.Balance
 }
 
-func (this EventWithdraw) PalletIndex() uint8 {
+func (ew EventWithdraw) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventWithdraw) PalletName() string {
+func (ew EventWithdraw) PalletName() string {
 	return PalletName
 }
 
-func (this EventWithdraw) EventIndex() uint8 {
+func (ew EventWithdraw) EventIndex() uint8 {
 	return 8
 }
 
-func (this EventWithdraw) EventName() string {
+func (ew EventWithdraw) EventName() string {
 	return "Withdraw"
 }

--- a/metadata/pallets/balances/storage.go
+++ b/metadata/pallets/balances/storage.go
@@ -10,16 +10,16 @@ type StorageTotalIssuance struct {
 	Value Balance
 }
 
-func (this *StorageTotalIssuance) PalletName() string {
+func (sti *StorageTotalIssuance) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageTotalIssuance) StorageName() string {
+func (sti *StorageTotalIssuance) StorageName() string {
 	return "TotalIssuance"
 }
 
-func (this *StorageTotalIssuance) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageTotalIssuance], error) {
-	return GenericFetch[StorageTotalIssuance](blockStorage, this)
+func (sti *StorageTotalIssuance) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageTotalIssuance], error) {
+	return GenericFetch[StorageTotalIssuance](blockStorage, sti)
 }
 
 //
@@ -30,16 +30,16 @@ type StorageInactiveIssuance struct {
 	Value Balance
 }
 
-func (this *StorageInactiveIssuance) PalletName() string {
+func (sii *StorageInactiveIssuance) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageInactiveIssuance) StorageName() string {
+func (sii *StorageInactiveIssuance) StorageName() string {
 	return "InactiveIssuance"
 }
 
-func (this *StorageInactiveIssuance) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageInactiveIssuance], error) {
-	return GenericFetch[StorageInactiveIssuance](blockStorage, this)
+func (sii *StorageInactiveIssuance) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageInactiveIssuance], error) {
+	return GenericFetch[StorageInactiveIssuance](blockStorage, sii)
 }
 
 //
@@ -53,24 +53,24 @@ type StorageLocks struct {
 	Value []BalanceLock
 }
 
-func (this *StorageLocks) PalletName() string {
+func (sl *StorageLocks) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageLocks) StorageName() string {
+func (sl *StorageLocks) StorageName() string {
 	return "Locks"
 }
 
-func (this *StorageLocks) MapKeyHasher() uint8 {
+func (sl *StorageLocks) MapKeyHasher() uint8 {
 	return Blake2_128ConcatHasher
 }
 
-func (this *StorageLocks) Fetch(blockStorage interfaces.BlockStorageT, key StorageLocksKey) (prim.Option[StorageLocksEntry], error) {
-	return GenericMapFetch[StorageLocks](blockStorage, key, this)
+func (sl *StorageLocks) Fetch(blockStorage interfaces.BlockStorageT, key StorageLocksKey) (prim.Option[StorageLocksEntry], error) {
+	return GenericMapFetch[StorageLocks](blockStorage, key, sl)
 }
 
-func (this *StorageLocks) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageLocksEntry, error) {
-	return GenericMapKeysFetch[StorageLocks, StorageLocksKey](blockStorage, this)
+func (sl *StorageLocks) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageLocksEntry, error) {
+	return GenericMapKeysFetch[StorageLocks, StorageLocksKey](blockStorage, sl)
 }
 
 type BalanceLock struct {
@@ -83,8 +83,8 @@ type Reasons struct {
 	VariantIndex uint8
 }
 
-func (this Reasons) ToString() string {
-	switch this.VariantIndex {
+func (r Reasons) ToString() string {
+	switch r.VariantIndex {
 	case 0:
 		return "Fee"
 	case 1:

--- a/metadata/pallets/data_availability/calls.go
+++ b/metadata/pallets/data_availability/calls.go
@@ -1,25 +1,23 @@
 package data_availability
 
-import ()
-
 // Do not add, remove or change any of the field members.
 type CallCreateApplicationKey struct {
 	Key []uint8
 }
 
-func (this CallCreateApplicationKey) PalletIndex() uint8 {
+func (ccak CallCreateApplicationKey) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallCreateApplicationKey) PalletName() string {
+func (ccak CallCreateApplicationKey) PalletName() string {
 	return PalletName
 }
 
-func (this CallCreateApplicationKey) CallIndex() uint8 {
+func (ccak CallCreateApplicationKey) CallIndex() uint8 {
 	return 0
 }
 
-func (this CallCreateApplicationKey) CallName() string {
+func (ccak CallCreateApplicationKey) CallName() string {
 	return "create_application_key"
 }
 
@@ -28,18 +26,18 @@ type CallSubmitData struct {
 	Data []uint8
 }
 
-func (this CallSubmitData) PalletIndex() uint8 {
+func (csd CallSubmitData) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSubmitData) PalletName() string {
+func (csd CallSubmitData) PalletName() string {
 	return PalletName
 }
 
-func (this CallSubmitData) CallIndex() uint8 {
+func (csd CallSubmitData) CallIndex() uint8 {
 	return 1
 }
 
-func (this CallSubmitData) CallName() string {
+func (csd CallSubmitData) CallName() string {
 	return "submit_data"
 }

--- a/metadata/pallets/data_availability/events.go
+++ b/metadata/pallets/data_availability/events.go
@@ -11,19 +11,19 @@ type EventApplicationKeyCreated struct {
 	Id    uint32 `scale:"compact"`
 }
 
-func (this EventApplicationKeyCreated) PalletIndex() uint8 {
+func (eakc EventApplicationKeyCreated) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventApplicationKeyCreated) PalletName() string {
+func (eakc EventApplicationKeyCreated) PalletName() string {
 	return PalletName
 }
 
-func (this EventApplicationKeyCreated) EventIndex() uint8 {
+func (eakc EventApplicationKeyCreated) EventIndex() uint8 {
 	return 0
 }
 
-func (this EventApplicationKeyCreated) EventName() string {
+func (eakc EventApplicationKeyCreated) EventName() string {
 	return "ApplicationKeyCreated"
 }
 
@@ -33,18 +33,18 @@ type EventDataSubmitted struct {
 	DataHash prim.H256
 }
 
-func (this EventDataSubmitted) PalletIndex() uint8 {
+func (eds EventDataSubmitted) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventDataSubmitted) PalletName() string {
+func (eds EventDataSubmitted) PalletName() string {
 	return PalletName
 }
 
-func (this EventDataSubmitted) EventIndex() uint8 {
+func (eds EventDataSubmitted) EventIndex() uint8 {
 	return 1
 }
 
-func (this EventDataSubmitted) EventName() string {
+func (eds EventDataSubmitted) EventName() string {
 	return "DataSubmitted"
 }

--- a/metadata/pallets/data_availability/storage.go
+++ b/metadata/pallets/data_availability/storage.go
@@ -10,16 +10,16 @@ type StorageNextAppId struct {
 	Value uint32 `scale:"compact"`
 }
 
-func (this *StorageNextAppId) PalletName() string {
+func (snai *StorageNextAppId) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageNextAppId) StorageName() string {
+func (snai *StorageNextAppId) StorageName() string {
 	return "NextAppId"
 }
 
-func (this *StorageNextAppId) Fetch(blockStorage interfaces.BlockStorageT) (uint32, error) {
-	val, err := GenericFetch[StorageNextAppId](blockStorage, this)
+func (snai *StorageNextAppId) Fetch(blockStorage interfaces.BlockStorageT) (uint32, error) {
+	val, err := GenericFetch[StorageNextAppId](blockStorage, snai)
 	if err != nil {
 		return 0, err
 	}
@@ -39,22 +39,22 @@ type StorageAppKeys struct {
 	AppId uint32 `scale:"compact"`
 }
 
-func (this *StorageAppKeys) PalletName() string {
+func (sak *StorageAppKeys) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageAppKeys) StorageName() string {
+func (sak *StorageAppKeys) StorageName() string {
 	return "AppKeys"
 }
 
-func (this *StorageAppKeys) MapKeyHasher() uint8 {
+func (sak *StorageAppKeys) MapKeyHasher() uint8 {
 	return Blake2_128ConcatHasher
 }
 
-func (this *StorageAppKeys) Fetch(blockStorage interfaces.BlockStorageT, key StorageAppKeysKey) (prim.Option[StorageAppKeysEntry], error) {
-	return GenericMapFetch[StorageAppKeys](blockStorage, key, this)
+func (sak *StorageAppKeys) Fetch(blockStorage interfaces.BlockStorageT, key StorageAppKeysKey) (prim.Option[StorageAppKeysEntry], error) {
+	return GenericMapFetch[StorageAppKeys](blockStorage, key, sak)
 }
 
-func (this *StorageAppKeys) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageAppKeysEntry, error) {
-	return GenericMapKeysFetch[StorageAppKeys, StorageAppKeysKey](blockStorage, this)
+func (sak *StorageAppKeys) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageAppKeysEntry, error) {
+	return GenericMapKeysFetch[StorageAppKeys, StorageAppKeysKey](blockStorage, sak)
 }

--- a/metadata/pallets/identity/storage.go
+++ b/metadata/pallets/identity/storage.go
@@ -12,22 +12,22 @@ type StorageIdentityOfEntry = StorageEntry[StorageIdentityOfKey, StorageIdentity
 
 type StorageIdentityOf struct{}
 
-func (this *StorageIdentityOf) PalletName() string {
+func (sio *StorageIdentityOf) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageIdentityOf) StorageName() string {
+func (sio *StorageIdentityOf) StorageName() string {
 	return "IdentityOf"
 }
 
-func (this *StorageIdentityOf) MapKeyHasher() uint8 {
+func (sio *StorageIdentityOf) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageIdentityOf) Fetch(blockStorage interfaces.BlockStorageT, key StorageIdentityOfKey) (prim.Option[StorageIdentityOfEntry], error) {
-	return GenericMapFetch[StorageIdentityOfValue](blockStorage, key, this)
+func (sio *StorageIdentityOf) Fetch(blockStorage interfaces.BlockStorageT, key StorageIdentityOfKey) (prim.Option[StorageIdentityOfEntry], error) {
+	return GenericMapFetch[StorageIdentityOfValue](blockStorage, key, sio)
 }
 
-func (this *StorageIdentityOf) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageIdentityOfEntry, error) {
-	return GenericMapKeysFetch[StorageIdentityOfValue, StorageIdentityOfKey](blockStorage, this)
+func (sio *StorageIdentityOf) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageIdentityOfEntry, error) {
+	return GenericMapKeysFetch[StorageIdentityOfValue, StorageIdentityOfKey](blockStorage, sio)
 }

--- a/metadata/pallets/mod.go
+++ b/metadata/pallets/mod.go
@@ -24,17 +24,17 @@ func ToPayload[T CallT](call T) meta.Payload {
 	return meta.NewPayload(ToCall(call), call.PalletName(), call.CallName())
 }
 
-func Decode[T CallT](this T, tx *prim.DecodedExtrinsic) bool {
-	if this.PalletIndex() != tx.Call.PalletIndex {
+func Decode[T CallT](c T, tx *prim.DecodedExtrinsic) bool {
+	if c.PalletIndex() != tx.Call.PalletIndex {
 		return false
 	}
 
-	if this.CallIndex() != tx.Call.CallIndex {
+	if c.CallIndex() != tx.Call.CallIndex {
 		return false
 	}
 
 	var decoder = prim.NewDecoder(tx.Call.Fields.ToBytes(), 0)
-	if err := decoder.Decode(this); err != nil {
+	if err := decoder.Decode(c); err != nil {
 		return false
 	}
 	return true

--- a/metadata/pallets/multisig/calls.go
+++ b/metadata/pallets/multisig/calls.go
@@ -19,19 +19,19 @@ type CallAsMultiThreshold1 struct {
 	Call             prim.Call
 }
 
-func (this CallAsMultiThreshold1) PalletIndex() uint8 {
+func (camt CallAsMultiThreshold1) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallAsMultiThreshold1) PalletName() string {
+func (camt CallAsMultiThreshold1) PalletName() string {
 	return PalletName
 }
 
-func (this CallAsMultiThreshold1) CallIndex() uint8 {
+func (camt CallAsMultiThreshold1) CallIndex() uint8 {
 	return 0
 }
 
-func (this CallAsMultiThreshold1) CallName() string {
+func (camt CallAsMultiThreshold1) CallName() string {
 	return "as_multi_threshold_1"
 }
 
@@ -68,19 +68,19 @@ type CallAsMulti struct {
 	MaxWeight        metadata.Weight
 }
 
-func (this CallAsMulti) PalletIndex() uint8 {
+func (cam CallAsMulti) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallAsMulti) PalletName() string {
+func (cam CallAsMulti) PalletName() string {
 	return PalletName
 }
 
-func (this CallAsMulti) CallIndex() uint8 {
+func (cam CallAsMulti) CallIndex() uint8 {
 	return 1
 }
 
-func (this CallAsMulti) CallName() string {
+func (cam CallAsMulti) CallName() string {
 	return "as_multi"
 }
 
@@ -110,19 +110,19 @@ type CallApproveAsMulti struct {
 	MaxWeight        metadata.Weight
 }
 
-func (this CallApproveAsMulti) PalletIndex() uint8 {
+func (caam CallApproveAsMulti) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallApproveAsMulti) PalletName() string {
+func (caam CallApproveAsMulti) PalletName() string {
 	return PalletName
 }
 
-func (this CallApproveAsMulti) CallIndex() uint8 {
+func (caam CallApproveAsMulti) CallIndex() uint8 {
 	return 2
 }
 
-func (this CallApproveAsMulti) CallName() string {
+func (caam CallApproveAsMulti) CallName() string {
 	return "approve_as_multi"
 }
 
@@ -144,18 +144,18 @@ type CallCancelAsMulti struct {
 	CallHash         prim.H256
 }
 
-func (this CallCancelAsMulti) PalletIndex() uint8 {
+func (ccam CallCancelAsMulti) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallCancelAsMulti) PalletName() string {
+func (ccam CallCancelAsMulti) PalletName() string {
 	return PalletName
 }
 
-func (this CallCancelAsMulti) CallIndex() uint8 {
+func (ccam CallCancelAsMulti) CallIndex() uint8 {
 	return 3
 }
 
-func (this CallCancelAsMulti) CallName() string {
+func (ccam CallCancelAsMulti) CallName() string {
 	return "cancel_as_multi"
 }

--- a/metadata/pallets/multisig/events.go
+++ b/metadata/pallets/multisig/events.go
@@ -10,76 +10,76 @@ type EventBatchInterrupted struct {
 	Error metadata.DispatchError
 }
 
-func (this EventBatchInterrupted) PalletIndex() uint8 {
+func (ebi EventBatchInterrupted) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventBatchInterrupted) PalletName() string {
+func (ebi EventBatchInterrupted) PalletName() string {
 	return PalletName
 }
 
-func (this EventBatchInterrupted) EventIndex() uint8 {
+func (ebi EventBatchInterrupted) EventIndex() uint8 {
 	return 0
 }
 
-func (this EventBatchInterrupted) EventName() string {
+func (ebi EventBatchInterrupted) EventName() string {
 	return "BatchInterrupted"
 }
 
 // Batch of dispatches completed fully with no error.
 type EventBatchCompleted struct{}
 
-func (this EventBatchCompleted) PalletIndex() uint8 {
+func (ebc EventBatchCompleted) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventBatchCompleted) PalletName() string {
+func (ebc EventBatchCompleted) PalletName() string {
 	return PalletName
 }
 
-func (this EventBatchCompleted) EventIndex() uint8 {
+func (ebc EventBatchCompleted) EventIndex() uint8 {
 	return 1
 }
 
-func (this EventBatchCompleted) EventName() string {
+func (ebc EventBatchCompleted) EventName() string {
 	return "BatchCompleted"
 }
 
 // Batch of dispatches completed but has errors.
 type EventBatchCompletedWithErrors struct{}
 
-func (this EventBatchCompletedWithErrors) PalletIndex() uint8 {
+func (ebcwe EventBatchCompletedWithErrors) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventBatchCompletedWithErrors) PalletName() string {
+func (ebcwe EventBatchCompletedWithErrors) PalletName() string {
 	return PalletName
 }
 
-func (this EventBatchCompletedWithErrors) EventIndex() uint8 {
+func (ebcwe EventBatchCompletedWithErrors) EventIndex() uint8 {
 	return 2
 }
 
-func (this EventBatchCompletedWithErrors) EventName() string {
+func (ebcwe EventBatchCompletedWithErrors) EventName() string {
 	return "BatchCompletedWithErrors"
 }
 
 // A single item within a Batch of dispatches has completed with no error.
 type EventItemCompleted struct{}
 
-func (this EventItemCompleted) PalletIndex() uint8 {
+func (eic EventItemCompleted) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventItemCompleted) PalletName() string {
+func (eic EventItemCompleted) PalletName() string {
 	return PalletName
 }
 
-func (this EventItemCompleted) EventIndex() uint8 {
+func (eic EventItemCompleted) EventIndex() uint8 {
 	return 3
 }
 
-func (this EventItemCompleted) EventName() string {
+func (eic EventItemCompleted) EventName() string {
 	return "ItemCompleted"
 }
 
@@ -88,19 +88,19 @@ type EventItemFailed struct {
 	Error metadata.DispatchError
 }
 
-func (this EventItemFailed) PalletIndex() uint8 {
+func (eif EventItemFailed) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventItemFailed) PalletName() string {
+func (eif EventItemFailed) PalletName() string {
 	return PalletName
 }
 
-func (this EventItemFailed) EventIndex() uint8 {
+func (eif EventItemFailed) EventIndex() uint8 {
 	return 4
 }
 
-func (this EventItemFailed) EventName() string {
+func (eif EventItemFailed) EventName() string {
 	return "ItemFailed"
 }
 
@@ -109,18 +109,18 @@ type EventDispatchedAs struct {
 	Result metadata.DispatchResult
 }
 
-func (this EventDispatchedAs) PalletIndex() uint8 {
+func (eda EventDispatchedAs) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventDispatchedAs) PalletName() string {
+func (eda EventDispatchedAs) PalletName() string {
 	return PalletName
 }
 
-func (this EventDispatchedAs) EventIndex() uint8 {
+func (eda EventDispatchedAs) EventIndex() uint8 {
 	return 5
 }
 
-func (this EventDispatchedAs) EventName() string {
+func (eda EventDispatchedAs) EventName() string {
 	return "DispatchedAs"
 }

--- a/metadata/pallets/nomination_pools/calls.go
+++ b/metadata/pallets/nomination_pools/calls.go
@@ -22,19 +22,19 @@ type CallJoin struct {
 	PoolId uint32
 }
 
-func (this CallJoin) PalletIndex() uint8 {
+func (cj CallJoin) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallJoin) PalletName() string {
+func (cj CallJoin) PalletName() string {
 	return PalletName
 }
 
-func (this CallJoin) CallIndex() uint8 {
+func (cj CallJoin) CallIndex() uint8 {
 	return 0
 }
 
-func (this CallJoin) CallName() string {
+func (cj CallJoin) CallName() string {
 	return "join"
 }
 
@@ -49,19 +49,19 @@ type CallBondExtra struct {
 	Extra metadata.PoolBondExtra
 }
 
-func (this CallBondExtra) PalletIndex() uint8 {
+func (cbe CallBondExtra) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallBondExtra) PalletName() string {
+func (cbe CallBondExtra) PalletName() string {
 	return PalletName
 }
 
-func (this CallBondExtra) CallIndex() uint8 {
+func (cbe CallBondExtra) CallIndex() uint8 {
 	return 1
 }
 
-func (this CallBondExtra) CallName() string {
+func (cbe CallBondExtra) CallName() string {
 	return "bond_extra"
 }
 
@@ -75,19 +75,19 @@ func (this CallBondExtra) CallName() string {
 // See `claim_payout_other` to caim rewards on bahalf of some `other` pool member.
 type CallClaimPayout struct{}
 
-func (this CallClaimPayout) PalletIndex() uint8 {
+func (ccp CallClaimPayout) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallClaimPayout) PalletName() string {
+func (ccp CallClaimPayout) PalletName() string {
 	return PalletName
 }
 
-func (this CallClaimPayout) CallIndex() uint8 {
+func (ccp CallClaimPayout) CallIndex() uint8 {
 	return 2
 }
 
-func (this CallClaimPayout) CallName() string {
+func (ccp CallClaimPayout) CallName() string {
 	return "claim_payout"
 }
 
@@ -127,19 +127,19 @@ type CallUnbond struct {
 	UnbondingPoints uint128.Uint128 `scale:"compact"`
 }
 
-func (this CallUnbond) PalletIndex() uint8 {
+func (cu CallUnbond) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallUnbond) PalletName() string {
+func (cu CallUnbond) PalletName() string {
 	return PalletName
 }
 
-func (this CallUnbond) CallIndex() uint8 {
+func (cu CallUnbond) CallIndex() uint8 {
 	return 3
 }
 
-func (this CallUnbond) CallName() string {
+func (cu CallUnbond) CallName() string {
 	return "unbond"
 }
 
@@ -154,19 +154,19 @@ type CallPoolWithdrawUnbonded struct {
 	NumSlashingSpans uint32
 }
 
-func (this CallPoolWithdrawUnbonded) PalletIndex() uint8 {
+func (cpwu CallPoolWithdrawUnbonded) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallPoolWithdrawUnbonded) PalletName() string {
+func (cpwu CallPoolWithdrawUnbonded) PalletName() string {
 	return PalletName
 }
 
-func (this CallPoolWithdrawUnbonded) CallIndex() uint8 {
+func (cpwu CallPoolWithdrawUnbonded) CallIndex() uint8 {
 	return 4
 }
 
-func (this CallPoolWithdrawUnbonded) CallName() string {
+func (cpwu CallPoolWithdrawUnbonded) CallName() string {
 	return "pool_withdraw_unbonded"
 }
 
@@ -194,19 +194,19 @@ type CallWithdrawUnbonded struct {
 	NumSlashingSpans uint32
 }
 
-func (this CallWithdrawUnbonded) PalletIndex() uint8 {
+func (cwu CallWithdrawUnbonded) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallWithdrawUnbonded) PalletName() string {
+func (cwu CallWithdrawUnbonded) PalletName() string {
 	return PalletName
 }
 
-func (this CallWithdrawUnbonded) CallIndex() uint8 {
+func (cwu CallWithdrawUnbonded) CallIndex() uint8 {
 	return 5
 }
 
-func (this CallWithdrawUnbonded) CallName() string {
+func (cwu CallWithdrawUnbonded) CallName() string {
 	return "withdraw_unbonded"
 }
 
@@ -232,19 +232,19 @@ type CallCreate struct {
 	Bouncer   prim.MultiAddress
 }
 
-func (this CallCreate) PalletIndex() uint8 {
+func (cc CallCreate) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallCreate) PalletName() string {
+func (cc CallCreate) PalletName() string {
 	return PalletName
 }
 
-func (this CallCreate) CallIndex() uint8 {
+func (cc CallCreate) CallIndex() uint8 {
 	return 6
 }
 
-func (this CallCreate) CallName() string {
+func (cc CallCreate) CallName() string {
 	return "create"
 }
 
@@ -262,19 +262,19 @@ type CallCreateWithPoolId struct {
 	PoolId    uint32
 }
 
-func (this CallCreateWithPoolId) PalletIndex() uint8 {
+func (ccwp CallCreateWithPoolId) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallCreateWithPoolId) PalletName() string {
+func (ccwp CallCreateWithPoolId) PalletName() string {
 	return PalletName
 }
 
-func (this CallCreateWithPoolId) CallIndex() uint8 {
+func (ccwp CallCreateWithPoolId) CallIndex() uint8 {
 	return 7
 }
 
-func (this CallCreateWithPoolId) CallName() string {
+func (ccwp CallCreateWithPoolId) CallName() string {
 	return "create_with_pool_id"
 }
 
@@ -290,19 +290,19 @@ type CallNominate struct {
 	Validators []prim.AccountId
 }
 
-func (this CallNominate) PalletIndex() uint8 {
+func (cn CallNominate) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallNominate) PalletName() string {
+func (cn CallNominate) PalletName() string {
 	return PalletName
 }
 
-func (this CallNominate) CallIndex() uint8 {
+func (cn CallNominate) CallIndex() uint8 {
 	return 8
 }
 
-func (this CallNominate) CallName() string {
+func (cn CallNominate) CallName() string {
 	return "nominate"
 }
 
@@ -321,19 +321,19 @@ type CallSetState struct {
 	State  metadata.PoolState
 }
 
-func (this CallSetState) PalletIndex() uint8 {
+func (css CallSetState) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSetState) PalletName() string {
+func (css CallSetState) PalletName() string {
 	return PalletName
 }
 
-func (this CallSetState) CallIndex() uint8 {
+func (css CallSetState) CallIndex() uint8 {
 	return 9
 }
 
-func (this CallSetState) CallName() string {
+func (css CallSetState) CallName() string {
 	return "set_state"
 }
 
@@ -346,19 +346,19 @@ type CallSetMetadata struct {
 	Metadata []byte
 }
 
-func (this CallSetMetadata) PalletIndex() uint8 {
+func (csm CallSetMetadata) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSetMetadata) PalletName() string {
+func (csm CallSetMetadata) PalletName() string {
 	return PalletName
 }
 
-func (this CallSetMetadata) CallIndex() uint8 {
+func (csm CallSetMetadata) CallIndex() uint8 {
 	return 10
 }
 
-func (this CallSetMetadata) CallName() string {
+func (csm CallSetMetadata) CallName() string {
 	return "set_metadata"
 }
 
@@ -376,19 +376,19 @@ type CallUpdateRoles struct {
 	NewBouncer   metadata.PoolRoleConfig
 }
 
-func (this CallUpdateRoles) PalletIndex() uint8 {
+func (cur CallUpdateRoles) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallUpdateRoles) PalletName() string {
+func (cur CallUpdateRoles) PalletName() string {
 	return PalletName
 }
 
-func (this CallUpdateRoles) CallIndex() uint8 {
+func (cur CallUpdateRoles) CallIndex() uint8 {
 	return 12
 }
 
-func (this CallUpdateRoles) CallName() string {
+func (cur CallUpdateRoles) CallName() string {
 	return "update_roles"
 }
 
@@ -403,19 +403,19 @@ type CallChill struct {
 	PoolId uint32
 }
 
-func (this CallChill) PalletIndex() uint8 {
+func (cc CallChill) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallChill) PalletName() string {
+func (cc CallChill) PalletName() string {
 	return PalletName
 }
 
-func (this CallChill) CallIndex() uint8 {
+func (cc CallChill) CallIndex() uint8 {
 	return 13
 }
 
-func (this CallChill) CallName() string {
+func (cc CallChill) CallName() string {
 	return "chill"
 }
 
@@ -433,19 +433,19 @@ type CallBondExtraOther struct {
 	Extra  metadata.PoolBondExtra
 }
 
-func (this CallBondExtraOther) PalletIndex() uint8 {
+func (cbeo CallBondExtraOther) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallBondExtraOther) PalletName() string {
+func (cbeo CallBondExtraOther) PalletName() string {
 	return PalletName
 }
 
-func (this CallBondExtraOther) CallIndex() uint8 {
+func (cbeo CallBondExtraOther) CallIndex() uint8 {
 	return 14
 }
 
-func (this CallBondExtraOther) CallName() string {
+func (cbeo CallBondExtraOther) CallName() string {
 	return "bond_extra_other"
 }
 
@@ -460,19 +460,19 @@ type CallSetClaimPermission struct {
 	Permission metadata.PoolClaimPermission
 }
 
-func (this CallSetClaimPermission) PalletIndex() uint8 {
+func (cscp CallSetClaimPermission) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSetClaimPermission) PalletName() string {
+func (cscp CallSetClaimPermission) PalletName() string {
 	return PalletName
 }
 
-func (this CallSetClaimPermission) CallIndex() uint8 {
+func (cscp CallSetClaimPermission) CallIndex() uint8 {
 	return 15
 }
 
-func (this CallSetClaimPermission) CallName() string {
+func (cscp CallSetClaimPermission) CallName() string {
 	return "set_claim_permission"
 }
 
@@ -484,19 +484,19 @@ type CallClaimPayoutOther struct {
 	Other prim.AccountId
 }
 
-func (this CallClaimPayoutOther) PalletIndex() uint8 {
+func (ccpo CallClaimPayoutOther) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallClaimPayoutOther) PalletName() string {
+func (ccpo CallClaimPayoutOther) PalletName() string {
 	return PalletName
 }
 
-func (this CallClaimPayoutOther) CallIndex() uint8 {
+func (ccpo CallClaimPayoutOther) CallIndex() uint8 {
 	return 16
 }
 
-func (this CallClaimPayoutOther) CallName() string {
+func (ccpo CallClaimPayoutOther) CallName() string {
 	return "claim_payout_other"
 }
 
@@ -511,19 +511,19 @@ type CallSetCommission struct {
 	NewCommission prim.Option[metadata.Tuple2[metadata.Perbill, prim.AccountId]]
 }
 
-func (this CallSetCommission) PalletIndex() uint8 {
+func (csc CallSetCommission) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSetCommission) PalletName() string {
+func (csc CallSetCommission) PalletName() string {
 	return PalletName
 }
 
-func (this CallSetCommission) CallIndex() uint8 {
+func (csc CallSetCommission) CallIndex() uint8 {
 	return 17
 }
 
-func (this CallSetCommission) CallName() string {
+func (csc CallSetCommission) CallName() string {
 	return "set_commission"
 }
 
@@ -537,19 +537,19 @@ type CallSetCommissionMax struct {
 	MaxCommission metadata.Perbill
 }
 
-func (this CallSetCommissionMax) PalletIndex() uint8 {
+func (cscm CallSetCommissionMax) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSetCommissionMax) PalletName() string {
+func (cscm CallSetCommissionMax) PalletName() string {
 	return PalletName
 }
 
-func (this CallSetCommissionMax) CallIndex() uint8 {
+func (cscm CallSetCommissionMax) CallIndex() uint8 {
 	return 18
 }
 
-func (this CallSetCommissionMax) CallName() string {
+func (cscm CallSetCommissionMax) CallName() string {
 	return "set_commission_max"
 }
 
@@ -562,19 +562,19 @@ type CallSetCommissionChangeRate struct {
 	ChangeRate metadata.PoolCommissionChangeRate
 }
 
-func (this CallSetCommissionChangeRate) PalletIndex() uint8 {
+func (csccr CallSetCommissionChangeRate) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSetCommissionChangeRate) PalletName() string {
+func (csccr CallSetCommissionChangeRate) PalletName() string {
 	return PalletName
 }
 
-func (this CallSetCommissionChangeRate) CallIndex() uint8 {
+func (csccr CallSetCommissionChangeRate) CallIndex() uint8 {
 	return 19
 }
 
-func (this CallSetCommissionChangeRate) CallName() string {
+func (csccr CallSetCommissionChangeRate) CallName() string {
 	return "set_commission_change_rate"
 }
 
@@ -587,19 +587,19 @@ type CallClaimCommission struct {
 	PoolId uint32
 }
 
-func (this CallClaimCommission) PalletIndex() uint8 {
+func (ccc CallClaimCommission) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallClaimCommission) PalletName() string {
+func (ccc CallClaimCommission) PalletName() string {
 	return PalletName
 }
 
-func (this CallClaimCommission) CallIndex() uint8 {
+func (ccc CallClaimCommission) CallIndex() uint8 {
 	return 20
 }
 
-func (this CallClaimCommission) CallName() string {
+func (ccc CallClaimCommission) CallName() string {
 	return "claim_commission"
 }
 
@@ -614,19 +614,19 @@ type CallAdjustPoolDeposit struct {
 	PoolId uint32
 }
 
-func (this CallAdjustPoolDeposit) PalletIndex() uint8 {
+func (capd CallAdjustPoolDeposit) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallAdjustPoolDeposit) PalletName() string {
+func (capd CallAdjustPoolDeposit) PalletName() string {
 	return PalletName
 }
 
-func (this CallAdjustPoolDeposit) CallIndex() uint8 {
+func (capd CallAdjustPoolDeposit) CallIndex() uint8 {
 	return 21
 }
 
-func (this CallAdjustPoolDeposit) CallName() string {
+func (capd CallAdjustPoolDeposit) CallName() string {
 	return "adjust_pool_deposit"
 }
 
@@ -639,18 +639,18 @@ type CallSetCommissionClaimPermission struct {
 	Permission prim.Option[metadata.CommissionClaimPermission]
 }
 
-func (this CallSetCommissionClaimPermission) PalletIndex() uint8 {
+func (csccp CallSetCommissionClaimPermission) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSetCommissionClaimPermission) PalletName() string {
+func (csccp CallSetCommissionClaimPermission) PalletName() string {
 	return PalletName
 }
 
-func (this CallSetCommissionClaimPermission) CallIndex() uint8 {
+func (csccp CallSetCommissionClaimPermission) CallIndex() uint8 {
 	return 22
 }
 
-func (this CallSetCommissionClaimPermission) CallName() string {
+func (csccp CallSetCommissionClaimPermission) CallName() string {
 	return "set_commission_claim_permission"
 }

--- a/metadata/pallets/nomination_pools/storage.go
+++ b/metadata/pallets/nomination_pools/storage.go
@@ -19,24 +19,24 @@ type StorageBondedPools struct {
 	State         PoolState
 }
 
-func (this *StorageBondedPools) PalletName() string {
+func (sbp *StorageBondedPools) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageBondedPools) StorageName() string {
+func (sbp *StorageBondedPools) StorageName() string {
 	return "BondedPools"
 }
 
-func (this *StorageBondedPools) MapKeyHasher() uint8 {
+func (sbp *StorageBondedPools) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageBondedPools) Fetch(blockStorage interfaces.BlockStorageT, key StorageBondedPoolsKey) (prim.Option[StorageBondedPoolsEntry], error) {
-	return GenericMapFetch[StorageBondedPools](blockStorage, key, this)
+func (sbp *StorageBondedPools) Fetch(blockStorage interfaces.BlockStorageT, key StorageBondedPoolsKey) (prim.Option[StorageBondedPoolsEntry], error) {
+	return GenericMapFetch[StorageBondedPools](blockStorage, key, sbp)
 }
 
-func (this *StorageBondedPools) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageBondedPoolsEntry, error) {
-	return GenericMapKeysFetch[StorageBondedPools, StorageBondedPoolsKey](blockStorage, this)
+func (sbp *StorageBondedPools) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageBondedPoolsEntry, error) {
+	return GenericMapKeysFetch[StorageBondedPools, StorageBondedPoolsKey](blockStorage, sbp)
 }
 
 //
@@ -55,25 +55,25 @@ type StorageClaimPermissions struct {
 	State         PoolState
 }
 
-func (this *StorageClaimPermissions) PalletName() string {
+func (scp *StorageClaimPermissions) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageClaimPermissions) StorageName() string {
+func (scp *StorageClaimPermissions) StorageName() string {
 	return "ClaimPermissions"
 }
 
-func (this *StorageClaimPermissions) MapKeyHasher() uint8 {
+func (scp *StorageClaimPermissions) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageClaimPermissions) Fetch(blockStorage interfaces.BlockStorageT, key StorageClaimPermissionsKey) (StorageClaimPermissionsEntry, error) {
-	val, err := GenericMapFetch[StorageClaimPermissionsValue](blockStorage, key, this)
+func (scp *StorageClaimPermissions) Fetch(blockStorage interfaces.BlockStorageT, key StorageClaimPermissionsKey) (StorageClaimPermissionsEntry, error) {
+	val, err := GenericMapFetch[StorageClaimPermissionsValue](blockStorage, key, scp)
 	return val.Unwrap(), err
 }
 
-func (this *StorageClaimPermissions) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageClaimPermissionsEntry, error) {
-	return GenericMapKeysFetch[StorageClaimPermissionsValue, StorageClaimPermissionsKey](blockStorage, this)
+func (scp *StorageClaimPermissions) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageClaimPermissionsEntry, error) {
+	return GenericMapKeysFetch[StorageClaimPermissionsValue, StorageClaimPermissionsKey](blockStorage, scp)
 }
 
 //
@@ -83,16 +83,16 @@ func (this *StorageClaimPermissions) FetchAll(blockStorage interfaces.BlockStora
 type StorageCounterForBondedPoolsValue = uint32
 type StorageCounterForBondedPools struct{}
 
-func (this *StorageCounterForBondedPools) PalletName() string {
+func (scfbp *StorageCounterForBondedPools) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageCounterForBondedPools) StorageName() string {
+func (scfbp *StorageCounterForBondedPools) StorageName() string {
 	return "CounterForBondedPools"
 }
 
-func (this *StorageCounterForBondedPools) Fetch(blockStorage interfaces.BlockStorageT) (StorageCounterForBondedPoolsValue, error) {
-	return GenericFetchDefault[StorageCounterForBondedPoolsValue](blockStorage, this)
+func (scfbp *StorageCounterForBondedPools) Fetch(blockStorage interfaces.BlockStorageT) (StorageCounterForBondedPoolsValue, error) {
+	return GenericFetchDefault[StorageCounterForBondedPoolsValue](blockStorage, scfbp)
 }
 
 //
@@ -102,16 +102,16 @@ func (this *StorageCounterForBondedPools) Fetch(blockStorage interfaces.BlockSto
 type StorageCounterForMetadataValue = uint32
 type StorageCounterForMetadata struct{}
 
-func (this *StorageCounterForMetadata) PalletName() string {
+func (scfm *StorageCounterForMetadata) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageCounterForMetadata) StorageName() string {
+func (scfm *StorageCounterForMetadata) StorageName() string {
 	return "CounterForMetadata"
 }
 
-func (this *StorageCounterForMetadata) Fetch(blockStorage interfaces.BlockStorageT) (StorageCounterForMetadataValue, error) {
-	return GenericFetchDefault[StorageCounterForMetadataValue](blockStorage, this)
+func (scfm *StorageCounterForMetadata) Fetch(blockStorage interfaces.BlockStorageT) (StorageCounterForMetadataValue, error) {
+	return GenericFetchDefault[StorageCounterForMetadataValue](blockStorage, scfm)
 }
 
 //
@@ -121,16 +121,16 @@ func (this *StorageCounterForMetadata) Fetch(blockStorage interfaces.BlockStorag
 type StorageCounterForPoolMembersValue = uint32
 type StorageCounterForPoolMembers struct{}
 
-func (this *StorageCounterForPoolMembers) PalletName() string {
+func (scfpm *StorageCounterForPoolMembers) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageCounterForPoolMembers) StorageName() string {
+func (scfpm *StorageCounterForPoolMembers) StorageName() string {
 	return "CounterForPoolMembers"
 }
 
-func (this *StorageCounterForPoolMembers) Fetch(blockStorage interfaces.BlockStorageT) (StorageCounterForPoolMembersValue, error) {
-	return GenericFetchDefault[StorageCounterForPoolMembersValue](blockStorage, this)
+func (scfpm *StorageCounterForPoolMembers) Fetch(blockStorage interfaces.BlockStorageT) (StorageCounterForPoolMembersValue, error) {
+	return GenericFetchDefault[StorageCounterForPoolMembersValue](blockStorage, scfpm)
 }
 
 //
@@ -140,16 +140,16 @@ func (this *StorageCounterForPoolMembers) Fetch(blockStorage interfaces.BlockSto
 type StorageCounterForReversePoolIdLookupValue = uint32
 type StorageCounterForReversePoolIdLookup struct{}
 
-func (this *StorageCounterForReversePoolIdLookup) PalletName() string {
+func (scfrpil *StorageCounterForReversePoolIdLookup) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageCounterForReversePoolIdLookup) StorageName() string {
+func (scfrpil *StorageCounterForReversePoolIdLookup) StorageName() string {
 	return "CounterForReversePoolIdLookup"
 }
 
-func (this *StorageCounterForReversePoolIdLookup) Fetch(blockStorage interfaces.BlockStorageT) (StorageCounterForReversePoolIdLookupValue, error) {
-	return GenericFetchDefault[StorageCounterForReversePoolIdLookupValue](blockStorage, this)
+func (scfrpil *StorageCounterForReversePoolIdLookup) Fetch(blockStorage interfaces.BlockStorageT) (StorageCounterForReversePoolIdLookupValue, error) {
+	return GenericFetchDefault[StorageCounterForReversePoolIdLookupValue](blockStorage, scfrpil)
 }
 
 //
@@ -159,16 +159,16 @@ func (this *StorageCounterForReversePoolIdLookup) Fetch(blockStorage interfaces.
 type StorageCounterForRewardPoolsValue = uint32
 type StorageCounterForRewardPools struct{}
 
-func (this *StorageCounterForRewardPools) PalletName() string {
+func (scfrp *StorageCounterForRewardPools) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageCounterForRewardPools) StorageName() string {
+func (scfrp *StorageCounterForRewardPools) StorageName() string {
 	return "CounterForRewardPools"
 }
 
-func (this *StorageCounterForRewardPools) Fetch(blockStorage interfaces.BlockStorageT) (StorageCounterForRewardPoolsValue, error) {
-	return GenericFetchDefault[StorageCounterForRewardPoolsValue](blockStorage, this)
+func (scfrp *StorageCounterForRewardPools) Fetch(blockStorage interfaces.BlockStorageT) (StorageCounterForRewardPoolsValue, error) {
+	return GenericFetchDefault[StorageCounterForRewardPoolsValue](blockStorage, scfrp)
 }
 
 //
@@ -178,16 +178,16 @@ func (this *StorageCounterForRewardPools) Fetch(blockStorage interfaces.BlockSto
 type StorageCounterForSubPoolsStorageValue = uint32
 type StorageCounterForSubPoolsStorage struct{}
 
-func (this *StorageCounterForSubPoolsStorage) PalletName() string {
+func (scfsps *StorageCounterForSubPoolsStorage) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageCounterForSubPoolsStorage) StorageName() string {
+func (scfsps *StorageCounterForSubPoolsStorage) StorageName() string {
 	return "CounterForSubPoolsStorage"
 }
 
-func (this *StorageCounterForSubPoolsStorage) Fetch(blockStorage interfaces.BlockStorageT) (StorageCounterForSubPoolsStorageValue, error) {
-	return GenericFetchDefault[StorageCounterForSubPoolsStorageValue](blockStorage, this)
+func (scfsps *StorageCounterForSubPoolsStorage) Fetch(blockStorage interfaces.BlockStorageT) (StorageCounterForSubPoolsStorageValue, error) {
+	return GenericFetchDefault[StorageCounterForSubPoolsStorageValue](blockStorage, scfsps)
 }
 
 //
@@ -197,16 +197,16 @@ func (this *StorageCounterForSubPoolsStorage) Fetch(blockStorage interfaces.Bloc
 type StorageGlobalMaxCommissionValue = Perbill
 type StorageGlobalMaxCommission struct{}
 
-func (this *StorageGlobalMaxCommission) PalletName() string {
+func (sgmc *StorageGlobalMaxCommission) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageGlobalMaxCommission) StorageName() string {
+func (sgmc *StorageGlobalMaxCommission) StorageName() string {
 	return "GlobalMaxCommission"
 }
 
-func (this *StorageGlobalMaxCommission) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageGlobalMaxCommissionValue], error) {
-	return GenericFetch[StorageGlobalMaxCommissionValue](blockStorage, this)
+func (sgmc *StorageGlobalMaxCommission) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageGlobalMaxCommissionValue], error) {
+	return GenericFetch[StorageGlobalMaxCommissionValue](blockStorage, sgmc)
 }
 
 //
@@ -216,16 +216,16 @@ func (this *StorageGlobalMaxCommission) Fetch(blockStorage interfaces.BlockStora
 type StorageLastPoolIdValue = uint32
 type StorageLastPoolId struct{}
 
-func (this *StorageLastPoolId) PalletName() string {
+func (slp *StorageLastPoolId) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageLastPoolId) StorageName() string {
+func (slp *StorageLastPoolId) StorageName() string {
 	return "LastPoolId"
 }
 
-func (this *StorageLastPoolId) Fetch(blockStorage interfaces.BlockStorageT) (StorageLastPoolIdValue, error) {
-	return GenericFetchDefault[StorageLastPoolIdValue](blockStorage, this)
+func (slp *StorageLastPoolId) Fetch(blockStorage interfaces.BlockStorageT) (StorageLastPoolIdValue, error) {
+	return GenericFetchDefault[StorageLastPoolIdValue](blockStorage, slp)
 }
 
 //
@@ -235,16 +235,16 @@ func (this *StorageLastPoolId) Fetch(blockStorage interfaces.BlockStorageT) (Sto
 type StorageMaxPoolMembersValue = uint32
 type StorageMaxPoolMembers struct{}
 
-func (this *StorageMaxPoolMembers) PalletName() string {
+func (smpm *StorageMaxPoolMembers) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageMaxPoolMembers) StorageName() string {
+func (smpm *StorageMaxPoolMembers) StorageName() string {
 	return "MaxPoolMembers"
 }
 
-func (this *StorageMaxPoolMembers) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageMaxPoolMembersValue], error) {
-	return GenericFetch[StorageMaxPoolMembersValue](blockStorage, this)
+func (smpm *StorageMaxPoolMembers) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageMaxPoolMembersValue], error) {
+	return GenericFetch[StorageMaxPoolMembersValue](blockStorage, smpm)
 }
 
 //
@@ -254,16 +254,16 @@ func (this *StorageMaxPoolMembers) Fetch(blockStorage interfaces.BlockStorageT) 
 type StorageMaxPoolMembersPerPoolValue = uint32
 type StorageMaxPoolMembersPerPool struct{}
 
-func (this *StorageMaxPoolMembersPerPool) PalletName() string {
+func (smpmpp *StorageMaxPoolMembersPerPool) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageMaxPoolMembersPerPool) StorageName() string {
+func (smpmpp *StorageMaxPoolMembersPerPool) StorageName() string {
 	return "MaxPoolMembersPerPool"
 }
 
-func (this *StorageMaxPoolMembersPerPool) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageMaxPoolMembersPerPoolValue], error) {
-	return GenericFetch[StorageMaxPoolMembersPerPoolValue](blockStorage, this)
+func (smpmpp *StorageMaxPoolMembersPerPool) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageMaxPoolMembersPerPoolValue], error) {
+	return GenericFetch[StorageMaxPoolMembersPerPoolValue](blockStorage, smpmpp)
 }
 
 //
@@ -273,16 +273,16 @@ func (this *StorageMaxPoolMembersPerPool) Fetch(blockStorage interfaces.BlockSto
 type StorageMaxPoolsValue = uint32
 type StorageMaxPools struct{}
 
-func (this *StorageMaxPools) PalletName() string {
+func (smp *StorageMaxPools) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageMaxPools) StorageName() string {
+func (smp *StorageMaxPools) StorageName() string {
 	return "MaxPools"
 }
 
-func (this *StorageMaxPools) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageMaxPoolsValue], error) {
-	return GenericFetch[StorageMaxPoolsValue](blockStorage, this)
+func (smp *StorageMaxPools) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageMaxPoolsValue], error) {
+	return GenericFetch[StorageMaxPoolsValue](blockStorage, smp)
 }
 
 //
@@ -295,25 +295,25 @@ type StorageMetadataEntry = StorageEntry[StorageMetadataKey, StorageMetadataValu
 
 type StorageMetadata struct{}
 
-func (this *StorageMetadata) PalletName() string {
+func (sm *StorageMetadata) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageMetadata) StorageName() string {
+func (sm *StorageMetadata) StorageName() string {
 	return "Metadata"
 }
 
-func (this *StorageMetadata) MapKeyHasher() uint8 {
+func (sm *StorageMetadata) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageMetadata) Fetch(blockStorage interfaces.BlockStorageT, key StorageMetadataKey) (StorageMetadataEntry, error) {
-	val, err := GenericMapFetch[StorageMetadataValue](blockStorage, key, this)
+func (sm *StorageMetadata) Fetch(blockStorage interfaces.BlockStorageT, key StorageMetadataKey) (StorageMetadataEntry, error) {
+	val, err := GenericMapFetch[StorageMetadataValue](blockStorage, key, sm)
 	return val.Unwrap(), err
 }
 
-func (this *StorageMetadata) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageMetadataEntry, error) {
-	return GenericMapKeysFetch[StorageMetadataValue, StorageMetadataKey](blockStorage, this)
+func (sm *StorageMetadata) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageMetadataEntry, error) {
+	return GenericMapKeysFetch[StorageMetadataValue, StorageMetadataKey](blockStorage, sm)
 }
 
 //
@@ -323,16 +323,16 @@ func (this *StorageMetadata) FetchAll(blockStorage interfaces.BlockStorageT) ([]
 type StorageMinCreateBondValue = Balance
 type StorageMinCreateBond struct{}
 
-func (this *StorageMinCreateBond) PalletName() string {
+func (smcb *StorageMinCreateBond) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageMinCreateBond) StorageName() string {
+func (smcb *StorageMinCreateBond) StorageName() string {
 	return "MinCreateBond"
 }
 
-func (this *StorageMinCreateBond) Fetch(blockStorage interfaces.BlockStorageT) (StorageMinCreateBondValue, error) {
-	return GenericFetchDefault[StorageMinCreateBondValue](blockStorage, this)
+func (smcb *StorageMinCreateBond) Fetch(blockStorage interfaces.BlockStorageT) (StorageMinCreateBondValue, error) {
+	return GenericFetchDefault[StorageMinCreateBondValue](blockStorage, smcb)
 }
 
 //
@@ -342,16 +342,16 @@ func (this *StorageMinCreateBond) Fetch(blockStorage interfaces.BlockStorageT) (
 type StorageMinJoinBondValue = Balance
 type StorageMinJoinBond struct{}
 
-func (this *StorageMinJoinBond) PalletName() string {
+func (smjb *StorageMinJoinBond) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageMinJoinBond) StorageName() string {
+func (smjb *StorageMinJoinBond) StorageName() string {
 	return "MinJoinBond"
 }
 
-func (this *StorageMinJoinBond) Fetch(blockStorage interfaces.BlockStorageT) (StorageMinJoinBondValue, error) {
-	return GenericFetchDefault[StorageMinJoinBondValue](blockStorage, this)
+func (smjb *StorageMinJoinBond) Fetch(blockStorage interfaces.BlockStorageT) (StorageMinJoinBondValue, error) {
+	return GenericFetchDefault[StorageMinJoinBondValue](blockStorage, smjb)
 }
 
 //
@@ -368,24 +368,24 @@ type StoragePoolMembers struct {
 	UnbondingEras            []Tuple2[uint32, uint128.Uint128]
 }
 
-func (this *StoragePoolMembers) PalletName() string {
+func (spm *StoragePoolMembers) PalletName() string {
 	return PalletName
 }
 
-func (this *StoragePoolMembers) StorageName() string {
+func (spm *StoragePoolMembers) StorageName() string {
 	return "PoolMembers"
 }
 
-func (this *StoragePoolMembers) MapKeyHasher() uint8 {
+func (spm *StoragePoolMembers) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StoragePoolMembers) Fetch(blockStorage interfaces.BlockStorageT, key StoragePoolMembersKey) (prim.Option[StoragePoolMembersEntry], error) {
-	return GenericMapFetch[StoragePoolMembers](blockStorage, key, this)
+func (spm *StoragePoolMembers) Fetch(blockStorage interfaces.BlockStorageT, key StoragePoolMembersKey) (prim.Option[StoragePoolMembersEntry], error) {
+	return GenericMapFetch[StoragePoolMembers](blockStorage, key, spm)
 }
 
-func (this *StoragePoolMembers) FetchAll(blockStorage interfaces.BlockStorageT) ([]StoragePoolMembersEntry, error) {
-	return GenericMapKeysFetch[StoragePoolMembers, StoragePoolMembersKey](blockStorage, this)
+func (spm *StoragePoolMembers) FetchAll(blockStorage interfaces.BlockStorageT) ([]StoragePoolMembersEntry, error) {
+	return GenericMapKeysFetch[StoragePoolMembers, StoragePoolMembersKey](blockStorage, spm)
 }
 
 //
@@ -398,24 +398,24 @@ type StorageReversePoolIdLookupEntry = StorageEntry[StorageReversePoolIdLookupKe
 
 type StorageReversePoolIdLookup struct{}
 
-func (this *StorageReversePoolIdLookup) PalletName() string {
+func (srpil *StorageReversePoolIdLookup) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageReversePoolIdLookup) StorageName() string {
+func (srpil *StorageReversePoolIdLookup) StorageName() string {
 	return "ReversePoolIdLookup"
 }
 
-func (this *StorageReversePoolIdLookup) MapKeyHasher() uint8 {
+func (srpil *StorageReversePoolIdLookup) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageReversePoolIdLookup) Fetch(blockStorage interfaces.BlockStorageT, key StorageReversePoolIdLookupKey) (prim.Option[StorageReversePoolIdLookupEntry], error) {
-	return GenericMapFetch[StorageReversePoolIdLookupValue](blockStorage, key, this)
+func (srpil *StorageReversePoolIdLookup) Fetch(blockStorage interfaces.BlockStorageT, key StorageReversePoolIdLookupKey) (prim.Option[StorageReversePoolIdLookupEntry], error) {
+	return GenericMapFetch[StorageReversePoolIdLookupValue](blockStorage, key, srpil)
 }
 
-func (this *StorageReversePoolIdLookup) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageReversePoolIdLookupEntry, error) {
-	return GenericMapKeysFetch[StorageReversePoolIdLookupValue, StorageReversePoolIdLookupKey](blockStorage, this)
+func (srpil *StorageReversePoolIdLookup) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageReversePoolIdLookupEntry, error) {
+	return GenericMapKeysFetch[StorageReversePoolIdLookupValue, StorageReversePoolIdLookupKey](blockStorage, srpil)
 }
 
 //
@@ -433,24 +433,24 @@ type StorageRewardPools struct {
 	TotalCommissionClaimed    Balance
 }
 
-func (this *StorageRewardPools) PalletName() string {
+func (srp *StorageRewardPools) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageRewardPools) StorageName() string {
+func (srp *StorageRewardPools) StorageName() string {
 	return "RewardPools"
 }
 
-func (this *StorageRewardPools) MapKeyHasher() uint8 {
+func (srp *StorageRewardPools) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageRewardPools) Fetch(blockStorage interfaces.BlockStorageT, key StorageRewardPoolsKey) (prim.Option[StorageRewardPoolsEntry], error) {
-	return GenericMapFetch[StorageRewardPools](blockStorage, key, this)
+func (srp *StorageRewardPools) Fetch(blockStorage interfaces.BlockStorageT, key StorageRewardPoolsKey) (prim.Option[StorageRewardPoolsEntry], error) {
+	return GenericMapFetch[StorageRewardPools](blockStorage, key, srp)
 }
 
-func (this *StorageRewardPools) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageRewardPoolsEntry, error) {
-	return GenericMapKeysFetch[StorageRewardPools, StorageRewardPoolsKey](blockStorage, this)
+func (srp *StorageRewardPools) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageRewardPoolsEntry, error) {
+	return GenericMapKeysFetch[StorageRewardPools, StorageRewardPoolsKey](blockStorage, srp)
 }
 
 //
@@ -470,24 +470,24 @@ type UnbondPool struct {
 	Balance Balance
 }
 
-func (this *StorageSubPoolsStorage) PalletName() string {
+func (ssps *StorageSubPoolsStorage) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageSubPoolsStorage) StorageName() string {
+func (ssps *StorageSubPoolsStorage) StorageName() string {
 	return "SubPoolsStorage"
 }
 
-func (this *StorageSubPoolsStorage) MapKeyHasher() uint8 {
+func (ssps *StorageSubPoolsStorage) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageSubPoolsStorage) Fetch(blockStorage interfaces.BlockStorageT, key StorageSubPoolsStorageKey) (prim.Option[StorageSubPoolsStorageEntry], error) {
-	return GenericMapFetch[StorageSubPoolsStorage](blockStorage, key, this)
+func (ssps *StorageSubPoolsStorage) Fetch(blockStorage interfaces.BlockStorageT, key StorageSubPoolsStorageKey) (prim.Option[StorageSubPoolsStorageEntry], error) {
+	return GenericMapFetch[StorageSubPoolsStorage](blockStorage, key, ssps)
 }
 
-func (this *StorageSubPoolsStorage) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageSubPoolsStorageEntry, error) {
-	return GenericMapKeysFetch[StorageSubPoolsStorage, StorageSubPoolsStorageKey](blockStorage, this)
+func (ssps *StorageSubPoolsStorage) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageSubPoolsStorageEntry, error) {
+	return GenericMapKeysFetch[StorageSubPoolsStorage, StorageSubPoolsStorageKey](blockStorage, ssps)
 }
 
 //
@@ -497,14 +497,14 @@ func (this *StorageSubPoolsStorage) FetchAll(blockStorage interfaces.BlockStorag
 type StorageTotalValueLockedValue = uint128.Uint128
 type StorageTotalValueLocked struct{}
 
-func (this *StorageTotalValueLocked) PalletName() string {
+func (stvl *StorageTotalValueLocked) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageTotalValueLocked) StorageName() string {
+func (stvl *StorageTotalValueLocked) StorageName() string {
 	return "TotalValueLocked"
 }
 
-func (this *StorageTotalValueLocked) Fetch(blockStorage interfaces.BlockStorageT) (StorageTotalValueLockedValue, error) {
-	return GenericFetchDefault[StorageTotalValueLockedValue](blockStorage, this)
+func (stvl *StorageTotalValueLocked) Fetch(blockStorage interfaces.BlockStorageT) (StorageTotalValueLockedValue, error) {
+	return GenericFetchDefault[StorageTotalValueLockedValue](blockStorage, stvl)
 }

--- a/metadata/pallets/proxy/calls.go
+++ b/metadata/pallets/proxy/calls.go
@@ -20,19 +20,19 @@ type CallProxy struct {
 	Call           prim.Call
 }
 
-func (this CallProxy) PalletIndex() uint8 {
+func (cp CallProxy) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallProxy) PalletName() string {
+func (cp CallProxy) PalletName() string {
 	return PalletName
 }
 
-func (this CallProxy) CallIndex() uint8 {
+func (cp CallProxy) CallIndex() uint8 {
 	return 0
 }
 
-func (this CallProxy) CallName() string {
+func (cp CallProxy) CallName() string {
 	return "proxy"
 }
 
@@ -51,19 +51,19 @@ type CallAddProxy struct {
 	Delay     uint32
 }
 
-func (this CallAddProxy) PalletIndex() uint8 {
+func (cap CallAddProxy) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallAddProxy) PalletName() string {
+func (cap CallAddProxy) PalletName() string {
 	return PalletName
 }
 
-func (this CallAddProxy) CallIndex() uint8 {
+func (cap CallAddProxy) CallIndex() uint8 {
 	return 1
 }
 
-func (this CallAddProxy) CallName() string {
+func (cap CallAddProxy) CallName() string {
 	return "add_proxy"
 }
 
@@ -81,19 +81,19 @@ type CallRemoveProxy struct {
 	Delay     uint32
 }
 
-func (this CallRemoveProxy) PalletIndex() uint8 {
+func (crp CallRemoveProxy) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallRemoveProxy) PalletName() string {
+func (crp CallRemoveProxy) PalletName() string {
 	return PalletName
 }
 
-func (this CallRemoveProxy) CallIndex() uint8 {
+func (crp CallRemoveProxy) CallIndex() uint8 {
 	return 2
 }
 
-func (this CallRemoveProxy) CallName() string {
+func (crp CallRemoveProxy) CallName() string {
 	return "remove_proxy"
 }
 
@@ -105,19 +105,19 @@ func (this CallRemoveProxy) CallName() string {
 // the unreserved fees will be inaccessible. **All access to this account will be lost.**
 type CallRemoveProxies struct{}
 
-func (this CallRemoveProxies) PalletIndex() uint8 {
+func (crps CallRemoveProxies) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallRemoveProxies) PalletName() string {
+func (crps CallRemoveProxies) PalletName() string {
 	return PalletName
 }
 
-func (this CallRemoveProxies) CallIndex() uint8 {
+func (crps CallRemoveProxies) CallIndex() uint8 {
 	return 3
 }
 
-func (this CallRemoveProxies) CallName() string {
+func (crps CallRemoveProxies) CallName() string {
 	return "remove_proxies"
 }
 
@@ -145,19 +145,19 @@ type CallCreatePure struct {
 	Index     uint16
 }
 
-func (this CallCreatePure) PalletIndex() uint8 {
+func (ccp CallCreatePure) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallCreatePure) PalletName() string {
+func (ccp CallCreatePure) PalletName() string {
 	return PalletName
 }
 
-func (this CallCreatePure) CallIndex() uint8 {
+func (ccp CallCreatePure) CallIndex() uint8 {
 	return 4
 }
 
-func (this CallCreatePure) CallName() string {
+func (ccp CallCreatePure) CallName() string {
 	return "create_pure"
 }
 
@@ -185,19 +185,19 @@ type CallKillPure struct {
 	ExtIndex  uint32 `scale:"compact"`
 }
 
-func (this CallKillPure) PalletIndex() uint8 {
+func (ckp CallKillPure) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallKillPure) PalletName() string {
+func (ckp CallKillPure) PalletName() string {
 	return PalletName
 }
 
-func (this CallKillPure) CallIndex() uint8 {
+func (ckp CallKillPure) CallIndex() uint8 {
 	return 5
 }
 
-func (this CallKillPure) CallName() string {
+func (ckp CallKillPure) CallName() string {
 	return "kill_pure"
 }
 
@@ -221,19 +221,19 @@ type CallAnnounce struct {
 	CallHash prim.H256
 }
 
-func (this CallAnnounce) PalletIndex() uint8 {
+func (ca CallAnnounce) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallAnnounce) PalletName() string {
+func (ca CallAnnounce) PalletName() string {
 	return PalletName
 }
 
-func (this CallAnnounce) CallIndex() uint8 {
+func (ca CallAnnounce) CallIndex() uint8 {
 	return 6
 }
 
-func (this CallAnnounce) CallName() string {
+func (ca CallAnnounce) CallName() string {
 	return "announce"
 }
 
@@ -252,19 +252,19 @@ type CallRemoveAnnouncement struct {
 	CallHash prim.H256
 }
 
-func (this CallRemoveAnnouncement) PalletIndex() uint8 {
+func (cra CallRemoveAnnouncement) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallRemoveAnnouncement) PalletName() string {
+func (cra CallRemoveAnnouncement) PalletName() string {
 	return PalletName
 }
 
-func (this CallRemoveAnnouncement) CallIndex() uint8 {
+func (cra CallRemoveAnnouncement) CallIndex() uint8 {
 	return 7
 }
 
-func (this CallRemoveAnnouncement) CallName() string {
+func (cra CallRemoveAnnouncement) CallName() string {
 	return "remove_announcement"
 }
 
@@ -283,19 +283,19 @@ type CallRejectAnnouncement struct {
 	CallHash prim.H256
 }
 
-func (this CallRejectAnnouncement) PalletIndex() uint8 {
+func (creja CallRejectAnnouncement) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallRejectAnnouncement) PalletName() string {
+func (creja CallRejectAnnouncement) PalletName() string {
 	return PalletName
 }
 
-func (this CallRejectAnnouncement) CallIndex() uint8 {
+func (creja CallRejectAnnouncement) CallIndex() uint8 {
 	return 8
 }
 
-func (this CallRejectAnnouncement) CallName() string {
+func (creja CallRejectAnnouncement) CallName() string {
 	return "reject_announcement"
 }
 
@@ -317,18 +317,18 @@ type CallProxyAnnounced struct {
 	Call           prim.Call
 }
 
-func (this CallProxyAnnounced) PalletIndex() uint8 {
+func (cpa CallProxyAnnounced) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallProxyAnnounced) PalletName() string {
+func (cpa CallProxyAnnounced) PalletName() string {
 	return PalletName
 }
 
-func (this CallProxyAnnounced) CallIndex() uint8 {
+func (cpa CallProxyAnnounced) CallIndex() uint8 {
 	return 9
 }
 
-func (this CallProxyAnnounced) CallName() string {
+func (cpa CallProxyAnnounced) CallName() string {
 	return "proxy_announced"
 }

--- a/metadata/pallets/proxy/events.go
+++ b/metadata/pallets/proxy/events.go
@@ -10,19 +10,19 @@ type EventProxyExecuted struct {
 	Result metadata.DispatchResult
 }
 
-func (this EventProxyExecuted) PalletIndex() uint8 {
+func (epe EventProxyExecuted) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventProxyExecuted) PalletName() string {
+func (epe EventProxyExecuted) PalletName() string {
 	return PalletName
 }
 
-func (this EventProxyExecuted) EventIndex() uint8 {
+func (epe EventProxyExecuted) EventIndex() uint8 {
 	return 0
 }
 
-func (this EventProxyExecuted) EventName() string {
+func (epe EventProxyExecuted) EventName() string {
 	return "ProxyExecuted"
 }
 
@@ -35,19 +35,19 @@ type EventPureCreated struct {
 	DisambiguationIndex uint16
 }
 
-func (this EventPureCreated) PalletIndex() uint8 {
+func (epc EventPureCreated) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventPureCreated) PalletName() string {
+func (epc EventPureCreated) PalletName() string {
 	return PalletName
 }
 
-func (this EventPureCreated) EventIndex() uint8 {
+func (epc EventPureCreated) EventIndex() uint8 {
 	return 1
 }
 
-func (this EventPureCreated) EventName() string {
+func (epc EventPureCreated) EventName() string {
 	return "PureCreated"
 }
 
@@ -58,19 +58,19 @@ type EventAnnounced struct {
 	CallHash primitives.H256
 }
 
-func (this EventAnnounced) PalletIndex() uint8 {
+func (ea EventAnnounced) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventAnnounced) PalletName() string {
+func (ea EventAnnounced) PalletName() string {
 	return PalletName
 }
 
-func (this EventAnnounced) EventIndex() uint8 {
+func (ea EventAnnounced) EventIndex() uint8 {
 	return 2
 }
 
-func (this EventAnnounced) EventName() string {
+func (ea EventAnnounced) EventName() string {
 	return "Announced"
 }
 
@@ -82,19 +82,19 @@ type EventProxyAdded struct {
 	Delay     uint32
 }
 
-func (this EventProxyAdded) PalletIndex() uint8 {
+func (epa EventProxyAdded) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventProxyAdded) PalletName() string {
+func (epa EventProxyAdded) PalletName() string {
 	return PalletName
 }
 
-func (this EventProxyAdded) EventIndex() uint8 {
+func (epa EventProxyAdded) EventIndex() uint8 {
 	return 3
 }
 
-func (this EventProxyAdded) EventName() string {
+func (epa EventProxyAdded) EventName() string {
 	return "ProxyAdded"
 }
 
@@ -106,18 +106,18 @@ type EventProxyRemoved struct {
 	Delay     uint32
 }
 
-func (this EventProxyRemoved) PalletIndex() uint8 {
+func (epr EventProxyRemoved) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventProxyRemoved) PalletName() string {
+func (epr EventProxyRemoved) PalletName() string {
 	return PalletName
 }
 
-func (this EventProxyRemoved) EventIndex() uint8 {
+func (epr EventProxyRemoved) EventIndex() uint8 {
 	return 4
 }
 
-func (this EventProxyRemoved) EventName() string {
+func (epr EventProxyRemoved) EventName() string {
 	return "ProxyRemoved"
 }

--- a/metadata/pallets/session/calls.go
+++ b/metadata/pallets/session/calls.go
@@ -12,19 +12,19 @@ type CallSetKeys struct {
 	Proof []byte
 }
 
-func (this CallSetKeys) PalletIndex() uint8 {
+func (csk CallSetKeys) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSetKeys) PalletName() string {
+func (csk CallSetKeys) PalletName() string {
 	return PalletName
 }
 
-func (this CallSetKeys) CallIndex() uint8 {
+func (csk CallSetKeys) CallIndex() uint8 {
 	return 0
 }
 
-func (this CallSetKeys) CallName() string {
+func (csk CallSetKeys) CallName() string {
 	return "set_keys"
 }
 
@@ -38,18 +38,18 @@ func (this CallSetKeys) CallName() string {
 // usually means being a stash account).
 type CallPurgeKeys struct{}
 
-func (this CallPurgeKeys) PalletIndex() uint8 {
+func (cpk CallPurgeKeys) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallPurgeKeys) PalletName() string {
+func (cpk CallPurgeKeys) PalletName() string {
 	return PalletName
 }
 
-func (this CallPurgeKeys) CallIndex() uint8 {
+func (cpk CallPurgeKeys) CallIndex() uint8 {
 	return 1
 }
 
-func (this CallPurgeKeys) CallName() string {
+func (cpk CallPurgeKeys) CallName() string {
 	return "purge_keys"
 }

--- a/metadata/pallets/session/storage.go
+++ b/metadata/pallets/session/storage.go
@@ -9,16 +9,16 @@ import (
 type StorageCurrentIndexValue = uint32
 type StorageCurrentIndex struct{}
 
-func (this *StorageCurrentIndex) PalletName() string {
+func (sci *StorageCurrentIndex) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageCurrentIndex) StorageName() string {
+func (sci *StorageCurrentIndex) StorageName() string {
 	return "CurrentIndex"
 }
 
-func (this *StorageCurrentIndex) Fetch(blockStorage interfaces.BlockStorageT) (StorageCurrentIndexValue, error) {
-	return GenericFetchDefault[StorageCurrentIndexValue](blockStorage, this)
+func (sci *StorageCurrentIndex) Fetch(blockStorage interfaces.BlockStorageT) (StorageCurrentIndexValue, error) {
+	return GenericFetchDefault[StorageCurrentIndexValue](blockStorage, sci)
 }
 
 //
@@ -28,16 +28,16 @@ func (this *StorageCurrentIndex) Fetch(blockStorage interfaces.BlockStorageT) (S
 type StorageDisabledValidatorsValue = []uint32
 type StorageDisabledValidators struct{}
 
-func (this *StorageDisabledValidators) PalletName() string {
+func (sdv *StorageDisabledValidators) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageDisabledValidators) StorageName() string {
+func (sdv *StorageDisabledValidators) StorageName() string {
 	return "DisabledValidators"
 }
 
-func (this *StorageDisabledValidators) Fetch(blockStorage interfaces.BlockStorageT) (StorageDisabledValidatorsValue, error) {
-	val, err := GenericFetch[StorageDisabledValidatorsValue](blockStorage, this)
+func (sdv *StorageDisabledValidators) Fetch(blockStorage interfaces.BlockStorageT) (StorageDisabledValidatorsValue, error) {
+	val, err := GenericFetch[StorageDisabledValidatorsValue](blockStorage, sdv)
 	return val.UnwrapOr(StorageDisabledValidatorsValue{}), err
 }
 
@@ -51,25 +51,25 @@ type StorageKeyOwnerEntry = StorageEntry[StorageKeyOwnerKey, StorageKeyOwnerValu
 
 type StorageKeyOwner struct{}
 
-func (this *StorageKeyOwner) PalletName() string {
+func (sko *StorageKeyOwner) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageKeyOwner) StorageName() string {
+func (sko *StorageKeyOwner) StorageName() string {
 	return "KeyOwner"
 }
 
-func (this *StorageKeyOwner) MapKeyHasher() uint8 {
+func (sko *StorageKeyOwner) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageKeyOwner) Fetch(blockStorage interfaces.BlockStorageT, key StorageKeyOwnerKey) (prim.Option[StorageKeyOwnerEntry], error) {
-	return GenericMapFetch[StorageKeyOwnerValue](blockStorage, key, this)
+func (sko *StorageKeyOwner) Fetch(blockStorage interfaces.BlockStorageT, key StorageKeyOwnerKey) (prim.Option[StorageKeyOwnerEntry], error) {
+	return GenericMapFetch[StorageKeyOwnerValue](blockStorage, key, sko)
 
 }
 
-func (this *StorageKeyOwner) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageKeyOwnerEntry, error) {
-	return GenericMapKeysFetch[StorageKeyOwnerValue, StorageKeyOwnerKey](blockStorage, this)
+func (sko *StorageKeyOwner) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageKeyOwnerEntry, error) {
+	return GenericMapKeysFetch[StorageKeyOwnerValue, StorageKeyOwnerKey](blockStorage, sko)
 }
 
 //
@@ -82,25 +82,25 @@ type StorageNextKeysEntry = StorageEntry[StorageNextKeysKey, StorageNextKeysValu
 
 type StorageNextKeys struct{}
 
-func (this *StorageNextKeys) PalletName() string {
+func (snk *StorageNextKeys) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageNextKeys) StorageName() string {
+func (snk *StorageNextKeys) StorageName() string {
 	return "NextKeys"
 }
 
-func (this *StorageNextKeys) MapKeyHasher() uint8 {
+func (snk *StorageNextKeys) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageNextKeys) Fetch(blockStorage interfaces.BlockStorageT, key StorageNextKeysKey) (prim.Option[StorageNextKeysEntry], error) {
-	return GenericMapFetch[StorageNextKeysValue](blockStorage, key, this)
+func (snk *StorageNextKeys) Fetch(blockStorage interfaces.BlockStorageT, key StorageNextKeysKey) (prim.Option[StorageNextKeysEntry], error) {
+	return GenericMapFetch[StorageNextKeysValue](blockStorage, key, snk)
 
 }
 
-func (this *StorageNextKeys) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageNextKeysEntry, error) {
-	return GenericMapKeysFetch[StorageNextKeysValue, StorageNextKeysKey](blockStorage, this)
+func (snk *StorageNextKeys) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageNextKeysEntry, error) {
+	return GenericMapKeysFetch[StorageNextKeysValue, StorageNextKeysKey](blockStorage, snk)
 }
 
 //
@@ -110,16 +110,16 @@ func (this *StorageNextKeys) FetchAll(blockStorage interfaces.BlockStorageT) ([]
 type StorageQueuedChangedValue = bool
 type StorageQueuedChanged struct{}
 
-func (this *StorageQueuedChanged) PalletName() string {
+func (sqc *StorageQueuedChanged) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageQueuedChanged) StorageName() string {
+func (sqc *StorageQueuedChanged) StorageName() string {
 	return "QueuedChanged"
 }
 
-func (this *StorageQueuedChanged) Fetch(blockStorage interfaces.BlockStorageT) (StorageQueuedChangedValue, error) {
-	return GenericFetchDefault[StorageQueuedChangedValue](blockStorage, this)
+func (sqc *StorageQueuedChanged) Fetch(blockStorage interfaces.BlockStorageT) (StorageQueuedChangedValue, error) {
+	return GenericFetchDefault[StorageQueuedChangedValue](blockStorage, sqc)
 }
 
 //
@@ -129,16 +129,16 @@ func (this *StorageQueuedChanged) Fetch(blockStorage interfaces.BlockStorageT) (
 type StorageQueuedKeysValue = []Tuple2[prim.AccountId, SessionKeys]
 type StorageQueuedKeys struct{}
 
-func (this *StorageQueuedKeys) PalletName() string {
+func (sqk *StorageQueuedKeys) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageQueuedKeys) StorageName() string {
+func (sqk *StorageQueuedKeys) StorageName() string {
 	return "QueuedKeys"
 }
 
-func (this *StorageQueuedKeys) Fetch(blockStorage interfaces.BlockStorageT) (StorageQueuedKeysValue, error) {
-	val, err := GenericFetch[StorageQueuedKeysValue](blockStorage, this)
+func (sqk *StorageQueuedKeys) Fetch(blockStorage interfaces.BlockStorageT) (StorageQueuedKeysValue, error) {
+	val, err := GenericFetch[StorageQueuedKeysValue](blockStorage, sqk)
 	return val.UnwrapOr(StorageQueuedKeysValue{}), err
 }
 
@@ -149,15 +149,15 @@ func (this *StorageQueuedKeys) Fetch(blockStorage interfaces.BlockStorageT) (Sto
 type StorageValidatorsValue = []prim.AccountId
 type StorageValidators struct{}
 
-func (this *StorageValidators) PalletName() string {
+func (sv *StorageValidators) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageValidators) StorageName() string {
+func (sv *StorageValidators) StorageName() string {
 	return "Validators"
 }
 
-func (this *StorageValidators) Fetch(blockStorage interfaces.BlockStorageT) (StorageValidatorsValue, error) {
-	val, err := GenericFetch[StorageValidatorsValue](blockStorage, this)
+func (sv *StorageValidators) Fetch(blockStorage interfaces.BlockStorageT) (StorageValidatorsValue, error) {
+	val, err := GenericFetch[StorageValidatorsValue](blockStorage, sv)
 	return val.UnwrapOr(StorageValidatorsValue{}), err
 }

--- a/metadata/pallets/staking/calls.go
+++ b/metadata/pallets/staking/calls.go
@@ -14,19 +14,19 @@ type CallBond struct {
 	Payee metadata.RewardDestination
 }
 
-func (this CallBond) PalletIndex() uint8 {
+func (cb CallBond) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallBond) PalletName() string {
+func (cb CallBond) PalletName() string {
 	return PalletName
 }
 
-func (this CallBond) CallIndex() uint8 {
+func (cb CallBond) CallIndex() uint8 {
 	return 0
 }
 
-func (this CallBond) CallName() string {
+func (cb CallBond) CallName() string {
 	return "bond"
 }
 
@@ -36,19 +36,19 @@ type CallBondExtra struct {
 	MaxAdditional metadata.Balance `scale:"compact"`
 }
 
-func (this CallBondExtra) PalletIndex() uint8 {
+func (cbe CallBondExtra) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallBondExtra) PalletName() string {
+func (cbe CallBondExtra) PalletName() string {
 	return PalletName
 }
 
-func (this CallBondExtra) CallIndex() uint8 {
+func (cbe CallBondExtra) CallIndex() uint8 {
 	return 1
 }
 
-func (this CallBondExtra) CallName() string {
+func (cbe CallBondExtra) CallName() string {
 	return "bond_extra"
 }
 
@@ -59,19 +59,19 @@ type CallUnbond struct {
 	Value metadata.Balance `scale:"compact"`
 }
 
-func (this CallUnbond) PalletIndex() uint8 {
+func (cu CallUnbond) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallUnbond) PalletName() string {
+func (cu CallUnbond) PalletName() string {
 	return PalletName
 }
 
-func (this CallUnbond) CallIndex() uint8 {
+func (cu CallUnbond) CallIndex() uint8 {
 	return 2
 }
 
-func (this CallUnbond) CallName() string {
+func (cu CallUnbond) CallName() string {
 	return "unbond"
 }
 
@@ -83,19 +83,19 @@ type CallWithdrawUnbonded struct {
 	NumSlashingSpans uint32
 }
 
-func (this CallWithdrawUnbonded) PalletIndex() uint8 {
+func (cwu CallWithdrawUnbonded) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallWithdrawUnbonded) PalletName() string {
+func (cwu CallWithdrawUnbonded) PalletName() string {
 	return PalletName
 }
 
-func (this CallWithdrawUnbonded) CallIndex() uint8 {
+func (cwu CallWithdrawUnbonded) CallIndex() uint8 {
 	return 3
 }
 
-func (this CallWithdrawUnbonded) CallName() string {
+func (cwu CallWithdrawUnbonded) CallName() string {
 	return "withdraw_unbonded"
 }
 
@@ -106,19 +106,19 @@ type CallValidate struct {
 	Prefs metadata.ValidatorPrefs
 }
 
-func (this CallValidate) PalletIndex() uint8 {
+func (cv CallValidate) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallValidate) PalletName() string {
+func (cv CallValidate) PalletName() string {
 	return PalletName
 }
 
-func (this CallValidate) CallIndex() uint8 {
+func (cv CallValidate) CallIndex() uint8 {
 	return 4
 }
 
-func (this CallValidate) CallName() string {
+func (cv CallValidate) CallName() string {
 	return "validate"
 }
 
@@ -129,19 +129,19 @@ type CallNominate struct {
 	Targets []prim.MultiAddress
 }
 
-func (this CallNominate) PalletIndex() uint8 {
+func (cn CallNominate) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallNominate) PalletName() string {
+func (cn CallNominate) PalletName() string {
 	return PalletName
 }
 
-func (this CallNominate) CallIndex() uint8 {
+func (cn CallNominate) CallIndex() uint8 {
 	return 5
 }
 
-func (this CallNominate) CallName() string {
+func (cn CallNominate) CallName() string {
 	return "nominate"
 }
 
@@ -150,19 +150,19 @@ func (this CallNominate) CallName() string {
 // Effects will be felt at the beginning of the next era.
 type CallChill struct{}
 
-func (this CallChill) PalletIndex() uint8 {
+func (cc CallChill) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallChill) PalletName() string {
+func (cc CallChill) PalletName() string {
 	return PalletName
 }
 
-func (this CallChill) CallIndex() uint8 {
+func (cc CallChill) CallIndex() uint8 {
 	return 6
 }
 
-func (this CallChill) CallName() string {
+func (cc CallChill) CallName() string {
 	return "chill"
 }
 
@@ -173,19 +173,19 @@ type CallSetPayee struct {
 	Payee metadata.RewardDestination
 }
 
-func (this CallSetPayee) PalletIndex() uint8 {
+func (csp CallSetPayee) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSetPayee) PalletName() string {
+func (csp CallSetPayee) PalletName() string {
 	return PalletName
 }
 
-func (this CallSetPayee) CallIndex() uint8 {
+func (csp CallSetPayee) CallIndex() uint8 {
 	return 7
 }
 
-func (this CallSetPayee) CallName() string {
+func (csp CallSetPayee) CallName() string {
 	return "set_payee"
 }
 
@@ -197,19 +197,19 @@ func (this CallSetPayee) CallName() string {
 // Effects will be felt instantly (as soon as this function is completed successfully).
 type CallSetController struct{}
 
-func (this CallSetController) PalletIndex() uint8 {
+func (csc CallSetController) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSetController) PalletName() string {
+func (csc CallSetController) PalletName() string {
 	return PalletName
 }
 
-func (this CallSetController) CallIndex() uint8 {
+func (csc CallSetController) CallIndex() uint8 {
 	return 8
 }
 
-func (this CallSetController) CallName() string {
+func (csc CallSetController) CallName() string {
 	return "set_controller"
 }
 
@@ -222,19 +222,19 @@ type CallPayoutStakers struct {
 	Era            uint32
 }
 
-func (this CallPayoutStakers) PalletIndex() uint8 {
+func (cps CallPayoutStakers) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallPayoutStakers) PalletName() string {
+func (cps CallPayoutStakers) PalletName() string {
 	return PalletName
 }
 
-func (this CallPayoutStakers) CallIndex() uint8 {
+func (cps CallPayoutStakers) CallIndex() uint8 {
 	return 18
 }
 
-func (this CallPayoutStakers) CallName() string {
+func (cps CallPayoutStakers) CallName() string {
 	return "payout_stakers"
 }
 
@@ -243,19 +243,19 @@ type CallRebond struct {
 	Value uint128.Uint128 `scale:"compact"`
 }
 
-func (this CallRebond) PalletIndex() uint8 {
+func (cr CallRebond) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallRebond) PalletName() string {
+func (cr CallRebond) PalletName() string {
 	return PalletName
 }
 
-func (this CallRebond) CallIndex() uint8 {
+func (cr CallRebond) CallIndex() uint8 {
 	return 19
 }
 
-func (this CallRebond) CallName() string {
+func (cr CallRebond) CallName() string {
 	return "rebond"
 }
 
@@ -276,19 +276,19 @@ type CallReapStash struct {
 	NumSlashingSpans uint32
 }
 
-func (this CallReapStash) PalletIndex() uint8 {
+func (crs CallReapStash) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallReapStash) PalletName() string {
+func (crs CallReapStash) PalletName() string {
 	return PalletName
 }
 
-func (this CallReapStash) CallIndex() uint8 {
+func (crs CallReapStash) CallIndex() uint8 {
 	return 20
 }
 
-func (this CallReapStash) CallName() string {
+func (crs CallReapStash) CallName() string {
 	return "reap_stash"
 }
 
@@ -299,19 +299,19 @@ type CallKick struct {
 	Who []prim.MultiAddress
 }
 
-func (this CallKick) PalletIndex() uint8 {
+func (ck CallKick) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallKick) PalletName() string {
+func (ck CallKick) PalletName() string {
 	return PalletName
 }
 
-func (this CallKick) CallIndex() uint8 {
+func (ck CallKick) CallIndex() uint8 {
 	return 21
 }
 
-func (this CallKick) CallName() string {
+func (ck CallKick) CallName() string {
 	return "kick"
 }
 
@@ -345,19 +345,19 @@ type CallChillOther struct {
 	Stash prim.AccountId
 }
 
-func (this CallChillOther) PalletIndex() uint8 {
+func (cco CallChillOther) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallChillOther) PalletName() string {
+func (cco CallChillOther) PalletName() string {
 	return PalletName
 }
 
-func (this CallChillOther) CallIndex() uint8 {
+func (cco CallChillOther) CallIndex() uint8 {
 	return 23
 }
 
-func (this CallChillOther) CallName() string {
+func (cco CallChillOther) CallName() string {
 	return "chill_other"
 }
 
@@ -368,19 +368,19 @@ type CallForceApplyMinCommission struct {
 	ValidatorStash prim.AccountId
 }
 
-func (this CallForceApplyMinCommission) PalletIndex() uint8 {
+func (cfamc CallForceApplyMinCommission) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallForceApplyMinCommission) PalletName() string {
+func (cfamc CallForceApplyMinCommission) PalletName() string {
 	return PalletName
 }
 
-func (this CallForceApplyMinCommission) CallIndex() uint8 {
+func (cfamc CallForceApplyMinCommission) CallIndex() uint8 {
 	return 24
 }
 
-func (this CallForceApplyMinCommission) CallName() string {
+func (cfamc CallForceApplyMinCommission) CallName() string {
 	return "force_apply_min_commission"
 }
 
@@ -407,19 +407,19 @@ type CallPayoutStakersByPage struct {
 	Page           uint32
 }
 
-func (this CallPayoutStakersByPage) PalletIndex() uint8 {
+func (cpsbp CallPayoutStakersByPage) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallPayoutStakersByPage) PalletName() string {
+func (cpsbp CallPayoutStakersByPage) PalletName() string {
 	return PalletName
 }
 
-func (this CallPayoutStakersByPage) CallIndex() uint8 {
+func (cpsbp CallPayoutStakersByPage) CallIndex() uint8 {
 	return 26
 }
 
-func (this CallPayoutStakersByPage) CallName() string {
+func (cpsbp CallPayoutStakersByPage) CallName() string {
 	return "payout_stakers_by_page"
 }
 
@@ -433,18 +433,18 @@ type CallUpdatePayee struct {
 	Controller prim.AccountId
 }
 
-func (this CallUpdatePayee) PalletIndex() uint8 {
+func (cup CallUpdatePayee) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallUpdatePayee) PalletName() string {
+func (cup CallUpdatePayee) PalletName() string {
 	return PalletName
 }
 
-func (this CallUpdatePayee) CallIndex() uint8 {
+func (cup CallUpdatePayee) CallIndex() uint8 {
 	return 27
 }
 
-func (this CallUpdatePayee) CallName() string {
+func (cup CallUpdatePayee) CallName() string {
 	return "update_payee"
 }

--- a/metadata/pallets/staking/storage.go
+++ b/metadata/pallets/staking/storage.go
@@ -11,16 +11,16 @@ type StorageActiveEra struct {
 	Start prim.Option[uint64]
 }
 
-func (this *StorageActiveEra) PalletName() string {
+func (sae *StorageActiveEra) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageActiveEra) StorageName() string {
+func (sae *StorageActiveEra) StorageName() string {
 	return "ActiveEra"
 }
 
-func (this *StorageActiveEra) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageActiveEra], error) {
-	return GenericFetch[StorageActiveEra](blockStorage, this)
+func (sae *StorageActiveEra) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageActiveEra], error) {
+	return GenericFetch[StorageActiveEra](blockStorage, sae)
 }
 
 //
@@ -33,24 +33,24 @@ type StorageBondedEntry = StorageEntry[StorageBondedKey, StorageBondedValue]
 
 type StorageBonded struct{}
 
-func (this *StorageBonded) PalletName() string {
+func (sb *StorageBonded) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageBonded) StorageName() string {
+func (sb *StorageBonded) StorageName() string {
 	return "Bonded"
 }
 
-func (this *StorageBonded) MapKeyHasher() uint8 {
+func (sb *StorageBonded) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageBonded) Fetch(blockStorage interfaces.BlockStorageT, key StorageBondedKey) (prim.Option[StorageBondedEntry], error) {
-	return GenericMapFetch[StorageBondedValue](blockStorage, key, this)
+func (sb *StorageBonded) Fetch(blockStorage interfaces.BlockStorageT, key StorageBondedKey) (prim.Option[StorageBondedEntry], error) {
+	return GenericMapFetch[StorageBondedValue](blockStorage, key, sb)
 }
 
-func (this *StorageBonded) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageBondedEntry, error) {
-	return GenericMapKeysFetch[StorageBondedValue, StorageBondedKey](blockStorage, this)
+func (sb *StorageBonded) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageBondedEntry, error) {
+	return GenericMapKeysFetch[StorageBondedValue, StorageBondedKey](blockStorage, sb)
 }
 
 //
@@ -60,16 +60,16 @@ func (this *StorageBonded) FetchAll(blockStorage interfaces.BlockStorageT) ([]St
 type BondedErasValue = []Tuple2[uint32, uint32]
 type StorageBondedEras struct{}
 
-func (this *StorageBondedEras) PalletName() string {
+func (sbe *StorageBondedEras) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageBondedEras) StorageName() string {
+func (sbe *StorageBondedEras) StorageName() string {
 	return "BondedEras"
 }
 
-func (this *StorageBondedEras) Fetch(blockStorage interfaces.BlockStorageT) (BondedErasValue, error) {
-	val, err := GenericFetch[BondedErasValue](blockStorage, this)
+func (sbe *StorageBondedEras) Fetch(blockStorage interfaces.BlockStorageT) (BondedErasValue, error) {
+	val, err := GenericFetch[BondedErasValue](blockStorage, sbe)
 	return val.UnwrapOr(BondedErasValue{}), err
 }
 
@@ -80,16 +80,16 @@ func (this *StorageBondedEras) Fetch(blockStorage interfaces.BlockStorageT) (Bon
 type StorageCanceledSlashPayoutValue = Balance
 type StorageCanceledSlashPayout struct{}
 
-func (this *StorageCanceledSlashPayout) PalletName() string {
+func (scsp *StorageCanceledSlashPayout) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageCanceledSlashPayout) StorageName() string {
+func (scsp *StorageCanceledSlashPayout) StorageName() string {
 	return "CanceledSlashPayout"
 }
 
-func (this *StorageCanceledSlashPayout) Fetch(blockStorage interfaces.BlockStorageT) (StorageCanceledSlashPayoutValue, error) {
-	return GenericFetchDefault[StorageCanceledSlashPayoutValue](blockStorage, this)
+func (scsp *StorageCanceledSlashPayout) Fetch(blockStorage interfaces.BlockStorageT) (StorageCanceledSlashPayoutValue, error) {
+	return GenericFetchDefault[StorageCanceledSlashPayoutValue](blockStorage, scsp)
 }
 
 //
@@ -99,16 +99,16 @@ func (this *StorageCanceledSlashPayout) Fetch(blockStorage interfaces.BlockStora
 type StorageChillThresholdValue = uint8
 type StorageChillThreshold struct{}
 
-func (this *StorageChillThreshold) PalletName() string {
+func (sct *StorageChillThreshold) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageChillThreshold) StorageName() string {
+func (sct *StorageChillThreshold) StorageName() string {
 	return "CanceledSlashPayout"
 }
 
-func (this *StorageChillThreshold) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageChillThresholdValue], error) {
-	return GenericFetch[StorageChillThresholdValue](blockStorage, this)
+func (sct *StorageChillThreshold) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageChillThresholdValue], error) {
+	return GenericFetch[StorageChillThresholdValue](blockStorage, sct)
 }
 
 //
@@ -121,29 +121,29 @@ type StorageClaimedRewardsValue = []uint32
 type StorageClaimedRewardsEntry = StorageEntryDoubleMap[StorageClaimedRewardsKey1, StorageClaimedRewardsKey2, StorageClaimedRewardsValue]
 type StorageClaimedRewards struct{}
 
-func (this *StorageClaimedRewards) PalletName() string {
+func (scr *StorageClaimedRewards) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageClaimedRewards) StorageName() string {
+func (scr *StorageClaimedRewards) StorageName() string {
 	return "ClaimedRewards"
 }
 
-func (this *StorageClaimedRewards) MapKey1Hasher() uint8 {
+func (scr *StorageClaimedRewards) MapKey1Hasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageClaimedRewards) MapKey2Hasher() uint8 {
+func (scr *StorageClaimedRewards) MapKey2Hasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageClaimedRewards) Fetch(blockStorage interfaces.BlockStorageT, key1 StorageClaimedRewardsKey1, key2 StorageClaimedRewardsKey2) (StorageClaimedRewardsEntry, error) {
-	val, err := GenericDoubleMapFetch[StorageClaimedRewardsValue](blockStorage, key1, key2, this)
+func (scr *StorageClaimedRewards) Fetch(blockStorage interfaces.BlockStorageT, key1 StorageClaimedRewardsKey1, key2 StorageClaimedRewardsKey2) (StorageClaimedRewardsEntry, error) {
+	val, err := GenericDoubleMapFetch[StorageClaimedRewardsValue](blockStorage, key1, key2, scr)
 	return val.Unwrap(), err
 }
 
-func (this *StorageClaimedRewards) FetchAll(blockStorage interfaces.BlockStorageT, key StorageClaimedRewardsKey1) ([]StorageClaimedRewardsEntry, error) {
-	return GenericDoubleMapKeysFetch[StorageClaimedRewardsValue, StorageClaimedRewardsKey1, StorageClaimedRewardsKey2](blockStorage, key, this)
+func (scr *StorageClaimedRewards) FetchAll(blockStorage interfaces.BlockStorageT, key StorageClaimedRewardsKey1) ([]StorageClaimedRewardsEntry, error) {
+	return GenericDoubleMapKeysFetch[StorageClaimedRewardsValue, StorageClaimedRewardsKey1, StorageClaimedRewardsKey2](blockStorage, key, scr)
 }
 
 //
@@ -153,16 +153,16 @@ func (this *StorageClaimedRewards) FetchAll(blockStorage interfaces.BlockStorage
 type StorageCounterForNominatorsValue = uint32
 type StorageCounterForNominators struct{}
 
-func (this *StorageCounterForNominators) PalletName() string {
+func (scfn *StorageCounterForNominators) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageCounterForNominators) StorageName() string {
+func (scfn *StorageCounterForNominators) StorageName() string {
 	return "CounterForNominators"
 }
 
-func (this *StorageCounterForNominators) Fetch(blockStorage interfaces.BlockStorageT) (StorageCounterForNominatorsValue, error) {
-	return GenericFetchDefault[StorageCounterForNominatorsValue](blockStorage, this)
+func (scfn *StorageCounterForNominators) Fetch(blockStorage interfaces.BlockStorageT) (StorageCounterForNominatorsValue, error) {
+	return GenericFetchDefault[StorageCounterForNominatorsValue](blockStorage, scfn)
 }
 
 //
@@ -172,16 +172,16 @@ func (this *StorageCounterForNominators) Fetch(blockStorage interfaces.BlockStor
 type StorageCounterForValidatorsValue = uint32
 type StorageCounterForValidators struct{}
 
-func (this *StorageCounterForValidators) PalletName() string {
+func (scfv *StorageCounterForValidators) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageCounterForValidators) StorageName() string {
+func (scfv *StorageCounterForValidators) StorageName() string {
 	return "CounterForValidators"
 }
 
-func (this *StorageCounterForValidators) Fetch(blockStorage interfaces.BlockStorageT) (StorageCounterForValidatorsValue, error) {
-	return GenericFetchDefault[StorageCounterForValidatorsValue](blockStorage, this)
+func (scfv *StorageCounterForValidators) Fetch(blockStorage interfaces.BlockStorageT) (StorageCounterForValidatorsValue, error) {
+	return GenericFetchDefault[StorageCounterForValidatorsValue](blockStorage, scfv)
 }
 
 //
@@ -191,16 +191,16 @@ func (this *StorageCounterForValidators) Fetch(blockStorage interfaces.BlockStor
 type StorageCurrentEraValue = uint32
 type StorageCurrentEra struct{}
 
-func (this *StorageCurrentEra) PalletName() string {
+func (sce *StorageCurrentEra) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageCurrentEra) StorageName() string {
+func (sce *StorageCurrentEra) StorageName() string {
 	return "CurrentEra"
 }
 
-func (this *StorageCurrentEra) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageCurrentEraValue], error) {
-	return GenericFetch[StorageCurrentEraValue](blockStorage, this)
+func (sce *StorageCurrentEra) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageCurrentEraValue], error) {
+	return GenericFetch[StorageCurrentEraValue](blockStorage, sce)
 }
 
 //
@@ -210,16 +210,16 @@ func (this *StorageCurrentEra) Fetch(blockStorage interfaces.BlockStorageT) (pri
 type StorageCurrentPlannedSessionValue = uint32
 type StorageCurrentPlannedSession struct{}
 
-func (this *StorageCurrentPlannedSession) PalletName() string {
+func (scps *StorageCurrentPlannedSession) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageCurrentPlannedSession) StorageName() string {
+func (scps *StorageCurrentPlannedSession) StorageName() string {
 	return "CurrentPlannedSession"
 }
 
-func (this *StorageCurrentPlannedSession) Fetch(blockStorage interfaces.BlockStorageT) (StorageCurrentPlannedSessionValue, error) {
-	return GenericFetchDefault[StorageCurrentPlannedSessionValue](blockStorage, this)
+func (scps *StorageCurrentPlannedSession) Fetch(blockStorage interfaces.BlockStorageT) (StorageCurrentPlannedSessionValue, error) {
+	return GenericFetchDefault[StorageCurrentPlannedSessionValue](blockStorage, scps)
 }
 
 //
@@ -234,26 +234,26 @@ type StorageErasRewardPoints struct {
 	Individual []Tuple2[prim.AccountId, uint32]
 }
 
-func (this *StorageErasRewardPoints) PalletName() string {
+func (serp *StorageErasRewardPoints) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageErasRewardPoints) StorageName() string {
+func (serp *StorageErasRewardPoints) StorageName() string {
 	return "ErasRewardPoints"
 }
 
-func (this *StorageErasRewardPoints) MapKeyHasher() uint8 {
+func (serp *StorageErasRewardPoints) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageErasRewardPoints) Fetch(blockStorage interfaces.BlockStorageT, key StorageErasRewardPointsKey) (StorageErasRewardPointsEntry, error) {
-	val, err := GenericMapFetch[StorageErasRewardPoints](blockStorage, key, this)
+func (serp *StorageErasRewardPoints) Fetch(blockStorage interfaces.BlockStorageT, key StorageErasRewardPointsKey) (StorageErasRewardPointsEntry, error) {
+	val, err := GenericMapFetch[StorageErasRewardPoints](blockStorage, key, serp)
 	return val.Unwrap(), err
 
 }
 
-func (this *StorageErasRewardPoints) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageErasRewardPointsEntry, error) {
-	return GenericMapKeysFetch[StorageErasRewardPoints, StorageErasRewardPointsKey](blockStorage, this)
+func (serp *StorageErasRewardPoints) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageErasRewardPointsEntry, error) {
+	return GenericMapKeysFetch[StorageErasRewardPoints, StorageErasRewardPointsKey](blockStorage, serp)
 }
 
 //
@@ -268,29 +268,29 @@ type StorageErasStakers struct {
 	Balance   Balance
 }
 
-func (this *StorageErasStakers) PalletName() string {
+func (ses *StorageErasStakers) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageErasStakers) StorageName() string {
+func (ses *StorageErasStakers) StorageName() string {
 	return "ErasStakers"
 }
 
-func (this *StorageErasStakers) MapKey1Hasher() uint8 {
+func (ses *StorageErasStakers) MapKey1Hasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageErasStakers) MapKey2Hasher() uint8 {
+func (ses *StorageErasStakers) MapKey2Hasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageErasStakers) Fetch(blockStorage interfaces.BlockStorageT, key1 StorageErasStakersKey1, key2 StorageErasStakersKey2) (StorageErasStakersEntry, error) {
-	val, err := GenericDoubleMapFetch[StorageErasStakers](blockStorage, key1, key2, this)
+func (ses *StorageErasStakers) Fetch(blockStorage interfaces.BlockStorageT, key1 StorageErasStakersKey1, key2 StorageErasStakersKey2) (StorageErasStakersEntry, error) {
+	val, err := GenericDoubleMapFetch[StorageErasStakers](blockStorage, key1, key2, ses)
 	return val.Unwrap(), err
 }
 
-func (this *StorageErasStakers) FetchAll(blockStorage interfaces.BlockStorageT, key StorageErasStakersKey1) ([]StorageErasStakersEntry, error) {
-	return GenericDoubleMapKeysFetch[StorageErasStakers, StorageErasStakersKey1, StorageErasStakersKey2](blockStorage, key, this)
+func (ses *StorageErasStakers) FetchAll(blockStorage interfaces.BlockStorageT, key StorageErasStakersKey1) ([]StorageErasStakersEntry, error) {
+	return GenericDoubleMapKeysFetch[StorageErasStakers, StorageErasStakersKey1, StorageErasStakersKey2](blockStorage, key, ses)
 }
 
 //
@@ -303,25 +303,25 @@ type StorageErasStartSessionIndexEntry = StorageEntry[StorageErasStartSessionInd
 
 type StorageErasStartSessionIndex struct{}
 
-func (this *StorageErasStartSessionIndex) PalletName() string {
+func (sessi *StorageErasStartSessionIndex) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageErasStartSessionIndex) StorageName() string {
+func (sessi *StorageErasStartSessionIndex) StorageName() string {
 	return "ErasStartSessionIndex"
 }
 
-func (this *StorageErasStartSessionIndex) MapKeyHasher() uint8 {
+func (sessi *StorageErasStartSessionIndex) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageErasStartSessionIndex) Fetch(blockStorage interfaces.BlockStorageT, key StorageErasStartSessionIndexKey) (prim.Option[StorageErasStartSessionIndexEntry], error) {
-	return GenericMapFetch[StorageErasStartSessionIndexValue](blockStorage, key, this)
+func (sessi *StorageErasStartSessionIndex) Fetch(blockStorage interfaces.BlockStorageT, key StorageErasStartSessionIndexKey) (prim.Option[StorageErasStartSessionIndexEntry], error) {
+	return GenericMapFetch[StorageErasStartSessionIndexValue](blockStorage, key, sessi)
 
 }
 
-func (this *StorageErasStartSessionIndex) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageErasStartSessionIndexEntry, error) {
-	return GenericMapKeysFetch[StorageErasStartSessionIndexValue, StorageErasStartSessionIndexKey](blockStorage, this)
+func (sessi *StorageErasStartSessionIndex) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageErasStartSessionIndexEntry, error) {
+	return GenericMapKeysFetch[StorageErasStartSessionIndexValue, StorageErasStartSessionIndexKey](blockStorage, sessi)
 }
 
 //
@@ -334,26 +334,26 @@ type StorageErasTotalStakeEntry = StorageEntry[StorageErasTotalStakeKey, Storage
 
 type StorageErasTotalStake struct{}
 
-func (this *StorageErasTotalStake) PalletName() string {
+func (sets *StorageErasTotalStake) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageErasTotalStake) StorageName() string {
+func (sets *StorageErasTotalStake) StorageName() string {
 	return "ErasTotalStake"
 }
 
-func (this *StorageErasTotalStake) MapKeyHasher() uint8 {
+func (sets *StorageErasTotalStake) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageErasTotalStake) Fetch(blockStorage interfaces.BlockStorageT, key StorageErasTotalStakeKey) (StorageErasTotalStakeEntry, error) {
-	val, err := GenericMapFetch[StorageErasTotalStakeValue](blockStorage, key, this)
+func (sets *StorageErasTotalStake) Fetch(blockStorage interfaces.BlockStorageT, key StorageErasTotalStakeKey) (StorageErasTotalStakeEntry, error) {
+	val, err := GenericMapFetch[StorageErasTotalStakeValue](blockStorage, key, sets)
 	return val.Unwrap(), err
 
 }
 
-func (this *StorageErasTotalStake) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageErasTotalStakeEntry, error) {
-	return GenericMapKeysFetch[StorageErasTotalStakeValue, StorageErasTotalStakeKey](blockStorage, this)
+func (sets *StorageErasTotalStake) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageErasTotalStakeEntry, error) {
+	return GenericMapKeysFetch[StorageErasTotalStakeValue, StorageErasTotalStakeKey](blockStorage, sets)
 }
 
 //
@@ -366,24 +366,24 @@ type StorageErasValidatorPrefsValue = ValidatorPrefs
 type StorageErasValidatorPrefsEntry = StorageEntryDoubleMap[StorageErasValidatorPrefsKey1, StorageErasValidatorPrefsKey2, StorageErasValidatorPrefsValue]
 type StorageErasValidatorPrefs struct{}
 
-func (this *StorageErasValidatorPrefs) PalletName() string {
+func (sevp *StorageErasValidatorPrefs) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageErasValidatorPrefs) StorageName() string {
+func (sevp *StorageErasValidatorPrefs) StorageName() string {
 	return "ErasValidatorPrefs"
 }
 
-func (this *StorageErasValidatorPrefs) MapKey1Hasher() uint8 {
+func (sevp *StorageErasValidatorPrefs) MapKey1Hasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageErasValidatorPrefs) MapKey2Hasher() uint8 {
+func (sevp *StorageErasValidatorPrefs) MapKey2Hasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageErasValidatorPrefs) Fetch(blockStorage interfaces.BlockStorageT, key1 StorageErasValidatorPrefsKey1, key2 StorageErasValidatorPrefsKey2) (StorageErasValidatorPrefsEntry, error) {
-	val, err := GenericDoubleMapFetch[StorageErasValidatorPrefsValue](blockStorage, key1, key2, this)
+func (sevp *StorageErasValidatorPrefs) Fetch(blockStorage interfaces.BlockStorageT, key1 StorageErasValidatorPrefsKey1, key2 StorageErasValidatorPrefsKey2) (StorageErasValidatorPrefsEntry, error) {
+	val, err := GenericDoubleMapFetch[StorageErasValidatorPrefsValue](blockStorage, key1, key2, sevp)
 	if err != nil {
 		return StorageErasValidatorPrefsEntry{}, err
 	}
@@ -391,8 +391,8 @@ func (this *StorageErasValidatorPrefs) Fetch(blockStorage interfaces.BlockStorag
 	return val.Unwrap(), nil
 }
 
-func (this *StorageErasValidatorPrefs) FetchAll(blockStorage interfaces.BlockStorageT, key StorageErasValidatorPrefsKey1) ([]StorageErasValidatorPrefsEntry, error) {
-	return GenericDoubleMapKeysFetch[StorageErasValidatorPrefsValue, StorageErasValidatorPrefsKey1, StorageErasValidatorPrefsKey2](blockStorage, key, this)
+func (sevp *StorageErasValidatorPrefs) FetchAll(blockStorage interfaces.BlockStorageT, key StorageErasValidatorPrefsKey1) ([]StorageErasValidatorPrefsEntry, error) {
+	return GenericDoubleMapKeysFetch[StorageErasValidatorPrefsValue, StorageErasValidatorPrefsKey1, StorageErasValidatorPrefsKey2](blockStorage, key, sevp)
 }
 
 //
@@ -405,25 +405,25 @@ type StorageErasValidatorRewardEntry = StorageEntry[StorageErasValidatorRewardKe
 
 type StorageErasValidatorReward struct{}
 
-func (this *StorageErasValidatorReward) PalletName() string {
+func (sevr *StorageErasValidatorReward) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageErasValidatorReward) StorageName() string {
+func (sevr *StorageErasValidatorReward) StorageName() string {
 	return "ErasValidatorReward"
 }
 
-func (this *StorageErasValidatorReward) MapKeyHasher() uint8 {
+func (sevr *StorageErasValidatorReward) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageErasValidatorReward) Fetch(blockStorage interfaces.BlockStorageT, key StorageErasValidatorRewardKey) (prim.Option[StorageErasValidatorRewardEntry], error) {
-	return GenericMapFetch[StorageErasValidatorRewardValue](blockStorage, key, this)
+func (sevr *StorageErasValidatorReward) Fetch(blockStorage interfaces.BlockStorageT, key StorageErasValidatorRewardKey) (prim.Option[StorageErasValidatorRewardEntry], error) {
+	return GenericMapFetch[StorageErasValidatorRewardValue](blockStorage, key, sevr)
 
 }
 
-func (this *StorageErasValidatorReward) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageErasValidatorRewardEntry, error) {
-	return GenericMapKeysFetch[StorageErasValidatorRewardValue, StorageErasValidatorRewardKey](blockStorage, this)
+func (sevr *StorageErasValidatorReward) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageErasValidatorRewardEntry, error) {
+	return GenericMapKeysFetch[StorageErasValidatorRewardValue, StorageErasValidatorRewardKey](blockStorage, sevr)
 }
 
 //
@@ -433,16 +433,16 @@ func (this *StorageErasValidatorReward) FetchAll(blockStorage interfaces.BlockSt
 type StorageInvulnerablesValue = []prim.AccountId
 type StorageInvulnerables struct{}
 
-func (this *StorageInvulnerables) PalletName() string {
+func (si *StorageInvulnerables) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageInvulnerables) StorageName() string {
+func (si *StorageInvulnerables) StorageName() string {
 	return "Invulnerables"
 }
 
-func (this *StorageInvulnerables) Fetch(blockStorage interfaces.BlockStorageT) (StorageInvulnerablesValue, error) {
-	val, err := GenericFetch[StorageInvulnerablesValue](blockStorage, this)
+func (si *StorageInvulnerables) Fetch(blockStorage interfaces.BlockStorageT) (StorageInvulnerablesValue, error) {
+	val, err := GenericFetch[StorageInvulnerablesValue](blockStorage, si)
 	return val.UnwrapOr(StorageInvulnerablesValue{}), err
 }
 
@@ -466,25 +466,25 @@ type UnlockChunk struct {
 	Era   uint32  `scale:"compact"`
 }
 
-func (this *StorageLedger) PalletName() string {
+func (sl *StorageLedger) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageLedger) StorageName() string {
+func (sl *StorageLedger) StorageName() string {
 	return "Ledger"
 }
 
-func (this *StorageLedger) MapKeyHasher() uint8 {
+func (sl *StorageLedger) MapKeyHasher() uint8 {
 	return Blake2_128ConcatHasher
 }
 
-func (this *StorageLedger) Fetch(blockStorage interfaces.BlockStorageT, key StorageLedgerKey) (prim.Option[StorageLedgerEntry], error) {
-	return GenericMapFetch[StorageLedger](blockStorage, key, this)
+func (sl *StorageLedger) Fetch(blockStorage interfaces.BlockStorageT, key StorageLedgerKey) (prim.Option[StorageLedgerEntry], error) {
+	return GenericMapFetch[StorageLedger](blockStorage, key, sl)
 
 }
 
-func (this *StorageLedger) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageLedgerEntry, error) {
-	return GenericMapKeysFetch[StorageLedger, StorageLedgerKey](blockStorage, this)
+func (sl *StorageLedger) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageLedgerEntry, error) {
+	return GenericMapKeysFetch[StorageLedger, StorageLedgerKey](blockStorage, sl)
 }
 
 //
@@ -494,16 +494,16 @@ func (this *StorageLedger) FetchAll(blockStorage interfaces.BlockStorageT) ([]St
 type StorageMaxNominatorsCountValue = uint32
 type StorageMaxNominatorsCount struct{}
 
-func (this *StorageMaxNominatorsCount) PalletName() string {
+func (smnc *StorageMaxNominatorsCount) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageMaxNominatorsCount) StorageName() string {
+func (smnc *StorageMaxNominatorsCount) StorageName() string {
 	return "MaxNominatorsCount"
 }
 
-func (this *StorageMaxNominatorsCount) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageMaxNominatorsCountValue], error) {
-	return GenericFetch[StorageMaxNominatorsCountValue](blockStorage, this)
+func (smnc *StorageMaxNominatorsCount) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageMaxNominatorsCountValue], error) {
+	return GenericFetch[StorageMaxNominatorsCountValue](blockStorage, smnc)
 }
 
 //
@@ -513,16 +513,16 @@ func (this *StorageMaxNominatorsCount) Fetch(blockStorage interfaces.BlockStorag
 type StorageMaxValidatorsCountValue = uint32
 type StorageMaxValidatorsCount struct{}
 
-func (this *StorageMaxValidatorsCount) PalletName() string {
+func (smvc *StorageMaxValidatorsCount) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageMaxValidatorsCount) StorageName() string {
+func (smvc *StorageMaxValidatorsCount) StorageName() string {
 	return "MaxValidatorsCount"
 }
 
-func (this *StorageMaxValidatorsCount) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageMaxValidatorsCountValue], error) {
-	return GenericFetch[StorageMaxValidatorsCountValue](blockStorage, this)
+func (smvc *StorageMaxValidatorsCount) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageMaxValidatorsCountValue], error) {
+	return GenericFetch[StorageMaxValidatorsCountValue](blockStorage, smvc)
 }
 
 //
@@ -532,16 +532,16 @@ func (this *StorageMaxValidatorsCount) Fetch(blockStorage interfaces.BlockStorag
 type StorageMinCommissionValue = Perbill
 type StorageMinCommission struct{}
 
-func (this *StorageMinCommission) PalletName() string {
+func (smc *StorageMinCommission) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageMinCommission) StorageName() string {
+func (smc *StorageMinCommission) StorageName() string {
 	return "MinCommission"
 }
 
-func (this *StorageMinCommission) Fetch(blockStorage interfaces.BlockStorageT) (StorageMinCommissionValue, error) {
-	return GenericFetchDefault[StorageMinCommissionValue](blockStorage, this)
+func (smc *StorageMinCommission) Fetch(blockStorage interfaces.BlockStorageT) (StorageMinCommissionValue, error) {
+	return GenericFetchDefault[StorageMinCommissionValue](blockStorage, smc)
 }
 
 //
@@ -551,16 +551,16 @@ func (this *StorageMinCommission) Fetch(blockStorage interfaces.BlockStorageT) (
 type StorageMinNominatorBondValue = Balance
 type StorageMinNominatorBond struct{}
 
-func (this *StorageMinNominatorBond) PalletName() string {
+func (smnb *StorageMinNominatorBond) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageMinNominatorBond) StorageName() string {
+func (smnb *StorageMinNominatorBond) StorageName() string {
 	return "MinNominatorBond"
 }
 
-func (this *StorageMinNominatorBond) Fetch(blockStorage interfaces.BlockStorageT) (StorageMinNominatorBondValue, error) {
-	return GenericFetchDefault[StorageMinNominatorBondValue](blockStorage, this)
+func (smnb *StorageMinNominatorBond) Fetch(blockStorage interfaces.BlockStorageT) (StorageMinNominatorBondValue, error) {
+	return GenericFetchDefault[StorageMinNominatorBondValue](blockStorage, smnb)
 }
 
 //
@@ -570,16 +570,16 @@ func (this *StorageMinNominatorBond) Fetch(blockStorage interfaces.BlockStorageT
 type StorageMinValidatorBondValue = Balance
 type StorageMinValidatorBond struct{}
 
-func (this *StorageMinValidatorBond) PalletName() string {
+func (smvb *StorageMinValidatorBond) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageMinValidatorBond) StorageName() string {
+func (smvb *StorageMinValidatorBond) StorageName() string {
 	return "MinValidatorBond"
 }
 
-func (this *StorageMinValidatorBond) Fetch(blockStorage interfaces.BlockStorageT) (StorageMinValidatorBondValue, error) {
-	return GenericFetchDefault[StorageMinValidatorBondValue](blockStorage, this)
+func (smvb *StorageMinValidatorBond) Fetch(blockStorage interfaces.BlockStorageT) (StorageMinValidatorBondValue, error) {
+	return GenericFetchDefault[StorageMinValidatorBondValue](blockStorage, smvb)
 }
 
 //
@@ -589,16 +589,16 @@ func (this *StorageMinValidatorBond) Fetch(blockStorage interfaces.BlockStorageT
 type StorageMinimumActiveStakeValue = Balance
 type StorageMinimumActiveStake struct{}
 
-func (this *StorageMinimumActiveStake) PalletName() string {
+func (smas *StorageMinimumActiveStake) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageMinimumActiveStake) StorageName() string {
+func (smas *StorageMinimumActiveStake) StorageName() string {
 	return "MinimumActiveStake"
 }
 
-func (this *StorageMinimumActiveStake) Fetch(blockStorage interfaces.BlockStorageT) (StorageMinimumActiveStakeValue, error) {
-	return GenericFetchDefault[StorageMinimumActiveStakeValue](blockStorage, this)
+func (smas *StorageMinimumActiveStake) Fetch(blockStorage interfaces.BlockStorageT) (StorageMinimumActiveStakeValue, error) {
+	return GenericFetchDefault[StorageMinimumActiveStakeValue](blockStorage, smas)
 }
 
 //
@@ -608,16 +608,16 @@ func (this *StorageMinimumActiveStake) Fetch(blockStorage interfaces.BlockStorag
 type StorageMinimumValidatorCountValue = uint32
 type StorageMinimumValidatorCount struct{}
 
-func (this *StorageMinimumValidatorCount) PalletName() string {
+func (smvc *StorageMinimumValidatorCount) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageMinimumValidatorCount) StorageName() string {
+func (smvc *StorageMinimumValidatorCount) StorageName() string {
 	return "MinimumValidatorCount"
 }
 
-func (this *StorageMinimumValidatorCount) Fetch(blockStorage interfaces.BlockStorageT) (StorageMinimumValidatorCountValue, error) {
-	return GenericFetchDefault[StorageMinimumValidatorCountValue](blockStorage, this)
+func (smvc *StorageMinimumValidatorCount) Fetch(blockStorage interfaces.BlockStorageT) (StorageMinimumValidatorCountValue, error) {
+	return GenericFetchDefault[StorageMinimumValidatorCountValue](blockStorage, smvc)
 }
 
 //
@@ -630,28 +630,28 @@ type StorageNominatorSlashInEraValue = Balance
 type StorageNominatorSlashInEraEntry = StorageEntryDoubleMap[StorageNominatorSlashInEraKey1, StorageNominatorSlashInEraKey2, StorageNominatorSlashInEraValue]
 type StorageNominatorSlashInEra struct{}
 
-func (this *StorageNominatorSlashInEra) PalletName() string {
+func (snsie *StorageNominatorSlashInEra) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageNominatorSlashInEra) StorageName() string {
+func (snsie *StorageNominatorSlashInEra) StorageName() string {
 	return "NominatorSlashInEra"
 }
 
-func (this *StorageNominatorSlashInEra) MapKey1Hasher() uint8 {
+func (snsie *StorageNominatorSlashInEra) MapKey1Hasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageNominatorSlashInEra) MapKey2Hasher() uint8 {
+func (snsie *StorageNominatorSlashInEra) MapKey2Hasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageNominatorSlashInEra) Fetch(blockStorage interfaces.BlockStorageT, key1 StorageNominatorSlashInEraKey1, key2 StorageNominatorSlashInEraKey2) (prim.Option[StorageNominatorSlashInEraEntry], error) {
-	return GenericDoubleMapFetch[StorageNominatorSlashInEraValue](blockStorage, key1, key2, this)
+func (snsie *StorageNominatorSlashInEra) Fetch(blockStorage interfaces.BlockStorageT, key1 StorageNominatorSlashInEraKey1, key2 StorageNominatorSlashInEraKey2) (prim.Option[StorageNominatorSlashInEraEntry], error) {
+	return GenericDoubleMapFetch[StorageNominatorSlashInEraValue](blockStorage, key1, key2, snsie)
 }
 
-func (this *StorageNominatorSlashInEra) FetchAll(blockStorage interfaces.BlockStorageT, key StorageNominatorSlashInEraKey1) ([]StorageNominatorSlashInEraEntry, error) {
-	return GenericDoubleMapKeysFetch[StorageNominatorSlashInEraValue, StorageNominatorSlashInEraKey1, StorageNominatorSlashInEraKey2](blockStorage, key, this)
+func (snsie *StorageNominatorSlashInEra) FetchAll(blockStorage interfaces.BlockStorageT, key StorageNominatorSlashInEraKey1) ([]StorageNominatorSlashInEraEntry, error) {
+	return GenericDoubleMapKeysFetch[StorageNominatorSlashInEraValue, StorageNominatorSlashInEraKey1, StorageNominatorSlashInEraKey2](blockStorage, key, snsie)
 }
 
 //
@@ -667,25 +667,25 @@ type StorageNominators struct {
 	Suppressed  bool
 }
 
-func (this *StorageNominators) PalletName() string {
+func (sn *StorageNominators) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageNominators) StorageName() string {
+func (sn *StorageNominators) StorageName() string {
 	return "Nominators"
 }
 
-func (this *StorageNominators) MapKeyHasher() uint8 {
+func (sn *StorageNominators) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageNominators) Fetch(blockStorage interfaces.BlockStorageT, key StorageNominatorsKey) (prim.Option[StorageNominatorsEntry], error) {
-	return GenericMapFetch[StorageNominators](blockStorage, key, this)
+func (sn *StorageNominators) Fetch(blockStorage interfaces.BlockStorageT, key StorageNominatorsKey) (prim.Option[StorageNominatorsEntry], error) {
+	return GenericMapFetch[StorageNominators](blockStorage, key, sn)
 
 }
 
-func (this *StorageNominators) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageNominatorsEntry, error) {
-	return GenericMapKeysFetch[StorageNominators, StorageNominatorsKey](blockStorage, this)
+func (sn *StorageNominators) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageNominatorsEntry, error) {
+	return GenericMapKeysFetch[StorageNominators, StorageNominatorsKey](blockStorage, sn)
 }
 
 //
@@ -695,16 +695,16 @@ func (this *StorageNominators) FetchAll(blockStorage interfaces.BlockStorageT) (
 type StorageOffendingValidatorsValue = []Tuple2[uint32, bool]
 type StorageOffendingValidators struct{}
 
-func (this *StorageOffendingValidators) PalletName() string {
+func (sov *StorageOffendingValidators) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageOffendingValidators) StorageName() string {
+func (sov *StorageOffendingValidators) StorageName() string {
 	return "OffendingValidators"
 }
 
-func (this *StorageOffendingValidators) Fetch(blockStorage interfaces.BlockStorageT) (StorageOffendingValidatorsValue, error) {
-	val, err := GenericFetch[StorageOffendingValidatorsValue](blockStorage, this)
+func (sov *StorageOffendingValidators) Fetch(blockStorage interfaces.BlockStorageT) (StorageOffendingValidatorsValue, error) {
+	val, err := GenericFetch[StorageOffendingValidatorsValue](blockStorage, sov)
 	return val.UnwrapOr(StorageOffendingValidatorsValue{}), err
 }
 
@@ -718,25 +718,25 @@ type StoragePayeeEntry = StorageEntry[StoragePayeeKey, StoragePayeeValue]
 
 type StoragePayee struct{}
 
-func (this *StoragePayee) PalletName() string {
+func (sp *StoragePayee) PalletName() string {
 	return PalletName
 }
 
-func (this *StoragePayee) StorageName() string {
+func (sp *StoragePayee) StorageName() string {
 	return "Payee"
 }
 
-func (this *StoragePayee) MapKeyHasher() uint8 {
+func (sp *StoragePayee) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StoragePayee) Fetch(blockStorage interfaces.BlockStorageT, key StoragePayeeKey) (prim.Option[StoragePayeeEntry], error) {
-	return GenericMapFetch[StoragePayeeValue](blockStorage, key, this)
+func (sp *StoragePayee) Fetch(blockStorage interfaces.BlockStorageT, key StoragePayeeKey) (prim.Option[StoragePayeeEntry], error) {
+	return GenericMapFetch[StoragePayeeValue](blockStorage, key, sp)
 
 }
 
-func (this *StoragePayee) FetchAll(blockStorage interfaces.BlockStorageT) ([]StoragePayeeEntry, error) {
-	return GenericMapKeysFetch[StoragePayeeValue, StoragePayeeKey](blockStorage, this)
+func (sp *StoragePayee) FetchAll(blockStorage interfaces.BlockStorageT) ([]StoragePayeeEntry, error) {
+	return GenericMapKeysFetch[StoragePayeeValue, StoragePayeeKey](blockStorage, sp)
 }
 
 //
@@ -746,16 +746,16 @@ func (this *StoragePayee) FetchAll(blockStorage interfaces.BlockStorageT) ([]Sto
 type StorageSlashRewardFractionValue = Perbill
 type StorageSlashRewardFraction struct{}
 
-func (this *StorageSlashRewardFraction) PalletName() string {
+func (ssrf *StorageSlashRewardFraction) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageSlashRewardFraction) StorageName() string {
+func (ssrf *StorageSlashRewardFraction) StorageName() string {
 	return "SlashRewardFraction "
 }
 
-func (this *StorageSlashRewardFraction) Fetch(blockStorage interfaces.BlockStorageT) (StorageSlashRewardFractionValue, error) {
-	return GenericFetchDefault[StorageSlashRewardFractionValue](blockStorage, this)
+func (ssrf *StorageSlashRewardFraction) Fetch(blockStorage interfaces.BlockStorageT) (StorageSlashRewardFractionValue, error) {
+	return GenericFetchDefault[StorageSlashRewardFractionValue](blockStorage, ssrf)
 }
 
 //
@@ -772,25 +772,25 @@ type StorageSlashingSpans struct {
 	Prior            []uint32
 }
 
-func (this *StorageSlashingSpans) PalletName() string {
+func (sss *StorageSlashingSpans) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageSlashingSpans) StorageName() string {
+func (sss *StorageSlashingSpans) StorageName() string {
 	return "SlashingSpans"
 }
 
-func (this *StorageSlashingSpans) MapKeyHasher() uint8 {
+func (sss *StorageSlashingSpans) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageSlashingSpans) Fetch(blockStorage interfaces.BlockStorageT, key StorageSlashingSpansKey) (prim.Option[StorageSlashingSpansEntry], error) {
-	return GenericMapFetch[StorageSlashingSpans](blockStorage, key, this)
+func (sss *StorageSlashingSpans) Fetch(blockStorage interfaces.BlockStorageT, key StorageSlashingSpansKey) (prim.Option[StorageSlashingSpansEntry], error) {
+	return GenericMapFetch[StorageSlashingSpans](blockStorage, key, sss)
 
 }
 
-func (this *StorageSlashingSpans) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageSlashingSpansEntry, error) {
-	return GenericMapKeysFetch[StorageSlashingSpans, StorageSlashingSpansKey](blockStorage, this)
+func (sss *StorageSlashingSpans) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageSlashingSpansEntry, error) {
+	return GenericMapKeysFetch[StorageSlashingSpans, StorageSlashingSpansKey](blockStorage, sss)
 }
 
 //
@@ -805,25 +805,25 @@ type StorageSpanSlash struct {
 	PaidOut Balance
 }
 
-func (this *StorageSpanSlash) PalletName() string {
+func (sss *StorageSpanSlash) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageSpanSlash) StorageName() string {
+func (sss *StorageSpanSlash) StorageName() string {
 	return "SpanSlash"
 }
 
-func (this *StorageSpanSlash) MapKeyHasher() uint8 {
+func (sss *StorageSpanSlash) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageSpanSlash) Fetch(blockStorage interfaces.BlockStorageT, key StorageSpanSlashKey) (prim.Option[StorageSpanSlashEntry], error) {
-	return GenericMapFetch[StorageSpanSlash](blockStorage, key, this)
+func (sss *StorageSpanSlash) Fetch(blockStorage interfaces.BlockStorageT, key StorageSpanSlashKey) (prim.Option[StorageSpanSlashEntry], error) {
+	return GenericMapFetch[StorageSpanSlash](blockStorage, key, sss)
 
 }
 
-func (this *StorageSpanSlash) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageSpanSlashEntry, error) {
-	return GenericMapKeysFetch[StorageSpanSlash, StorageSpanSlashKey](blockStorage, this)
+func (sss *StorageSpanSlash) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageSpanSlashEntry, error) {
+	return GenericMapKeysFetch[StorageSpanSlash, StorageSpanSlashKey](blockStorage, sss)
 }
 
 //
@@ -842,26 +842,26 @@ type StorageUnappliedSlashes struct {
 	Payout    Balance
 }
 
-func (this *StorageUnappliedSlashes) PalletName() string {
+func (sus *StorageUnappliedSlashes) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageUnappliedSlashes) StorageName() string {
+func (sus *StorageUnappliedSlashes) StorageName() string {
 	return "UnappliedSlashes"
 }
 
-func (this *StorageUnappliedSlashes) MapKeyHasher() uint8 {
+func (sus *StorageUnappliedSlashes) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageUnappliedSlashes) Fetch(blockStorage interfaces.BlockStorageT, key StorageUnappliedSlashesKey) (StorageUnappliedSlashesEntry, error) {
-	val, err := GenericMapFetch[StorageUnappliedSlashesValue](blockStorage, key, this)
+func (sus *StorageUnappliedSlashes) Fetch(blockStorage interfaces.BlockStorageT, key StorageUnappliedSlashesKey) (StorageUnappliedSlashesEntry, error) {
+	val, err := GenericMapFetch[StorageUnappliedSlashesValue](blockStorage, key, sus)
 	return val.UnwrapOr(StorageUnappliedSlashesEntry{}), err
 
 }
 
-func (this *StorageUnappliedSlashes) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageUnappliedSlashesEntry, error) {
-	return GenericMapKeysFetch[StorageUnappliedSlashesValue, StorageUnappliedSlashesKey](blockStorage, this)
+func (sus *StorageUnappliedSlashes) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageUnappliedSlashesEntry, error) {
+	return GenericMapKeysFetch[StorageUnappliedSlashesValue, StorageUnappliedSlashesKey](blockStorage, sus)
 }
 
 //
@@ -871,16 +871,16 @@ func (this *StorageUnappliedSlashes) FetchAll(blockStorage interfaces.BlockStora
 type StorageValidatorCountValue = uint32
 type StorageValidatorCount struct{}
 
-func (this *StorageValidatorCount) PalletName() string {
+func (svc *StorageValidatorCount) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageValidatorCount) StorageName() string {
+func (svc *StorageValidatorCount) StorageName() string {
 	return "ValidatorCount"
 }
 
-func (this *StorageValidatorCount) Fetch(blockStorage interfaces.BlockStorageT) (StorageValidatorCountValue, error) {
-	return GenericFetchDefault[StorageValidatorCountValue](blockStorage, this)
+func (svc *StorageValidatorCount) Fetch(blockStorage interfaces.BlockStorageT) (StorageValidatorCountValue, error) {
+	return GenericFetchDefault[StorageValidatorCountValue](blockStorage, svc)
 }
 
 //
@@ -893,28 +893,28 @@ type StorageValidatorSlashInEraValue = Tuple2[Perbill, Balance]
 type StorageValidatorSlashInEraEntry = StorageEntryDoubleMap[StorageValidatorSlashInEraKey1, StorageValidatorSlashInEraKey2, StorageValidatorSlashInEraValue]
 type StorageValidatorSlashInEra struct{}
 
-func (this *StorageValidatorSlashInEra) PalletName() string {
+func (svsie *StorageValidatorSlashInEra) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageValidatorSlashInEra) StorageName() string {
+func (svsie *StorageValidatorSlashInEra) StorageName() string {
 	return "ValidatorSlashInEra"
 }
 
-func (this *StorageValidatorSlashInEra) MapKey1Hasher() uint8 {
+func (svsie *StorageValidatorSlashInEra) MapKey1Hasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageValidatorSlashInEra) MapKey2Hasher() uint8 {
+func (svsie *StorageValidatorSlashInEra) MapKey2Hasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageValidatorSlashInEra) Fetch(blockStorage interfaces.BlockStorageT, key1 StorageValidatorSlashInEraKey1, key2 StorageValidatorSlashInEraKey2) (prim.Option[StorageValidatorSlashInEraEntry], error) {
-	return GenericDoubleMapFetch[StorageValidatorSlashInEraValue](blockStorage, key1, key2, this)
+func (svsie *StorageValidatorSlashInEra) Fetch(blockStorage interfaces.BlockStorageT, key1 StorageValidatorSlashInEraKey1, key2 StorageValidatorSlashInEraKey2) (prim.Option[StorageValidatorSlashInEraEntry], error) {
+	return GenericDoubleMapFetch[StorageValidatorSlashInEraValue](blockStorage, key1, key2, svsie)
 }
 
-func (this *StorageValidatorSlashInEra) FetchAll(blockStorage interfaces.BlockStorageT, key StorageValidatorSlashInEraKey1) ([]StorageValidatorSlashInEraEntry, error) {
-	return GenericDoubleMapKeysFetch[StorageValidatorSlashInEraValue, StorageValidatorSlashInEraKey1, StorageValidatorSlashInEraKey2](blockStorage, key, this)
+func (svsie *StorageValidatorSlashInEra) FetchAll(blockStorage interfaces.BlockStorageT, key StorageValidatorSlashInEraKey1) ([]StorageValidatorSlashInEraEntry, error) {
+	return GenericDoubleMapKeysFetch[StorageValidatorSlashInEraValue, StorageValidatorSlashInEraKey1, StorageValidatorSlashInEraKey2](blockStorage, key, svsie)
 }
 
 //
@@ -930,24 +930,24 @@ type StorageValidators struct {
 	PaidOut Balance
 }
 
-func (this *StorageValidators) PalletName() string {
+func (sv *StorageValidators) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageValidators) StorageName() string {
+func (sv *StorageValidators) StorageName() string {
 	return "Validators"
 }
 
-func (this *StorageValidators) MapKeyHasher() uint8 {
+func (sv *StorageValidators) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageValidators) Fetch(blockStorage interfaces.BlockStorageT, key StorageValidatorsKey) (StorageValidatorsEntry, error) {
-	val, err := GenericMapFetch[StorageValidatorsValue](blockStorage, key, this)
+func (sv *StorageValidators) Fetch(blockStorage interfaces.BlockStorageT, key StorageValidatorsKey) (StorageValidatorsEntry, error) {
+	val, err := GenericMapFetch[StorageValidatorsValue](blockStorage, key, sv)
 	return val.Unwrap(), err
 
 }
 
-func (this *StorageValidators) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageValidatorsEntry, error) {
-	return GenericMapKeysFetch[StorageValidatorsValue, StorageValidatorsKey](blockStorage, this)
+func (sv *StorageValidators) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageValidatorsEntry, error) {
+	return GenericMapKeysFetch[StorageValidatorsValue, StorageValidatorsKey](blockStorage, sv)
 }

--- a/metadata/pallets/sudo/calls.go
+++ b/metadata/pallets/sudo/calls.go
@@ -9,19 +9,19 @@ type CallSudo struct {
 	Call prim.Call
 }
 
-func (this CallSudo) PalletIndex() uint8 {
+func (cs CallSudo) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSudo) PalletName() string {
+func (cs CallSudo) PalletName() string {
 	return PalletName
 }
 
-func (this CallSudo) CallIndex() uint8 {
+func (cs CallSudo) CallIndex() uint8 {
 	return 0
 }
 
-func (this CallSudo) CallName() string {
+func (cs CallSudo) CallName() string {
 	return "sudo"
 }
 
@@ -34,19 +34,19 @@ type CallSudoUncheckedWeight struct {
 	Call prim.Call
 }
 
-func (this CallSudoUncheckedWeight) PalletIndex() uint8 {
+func (csuw CallSudoUncheckedWeight) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSudoUncheckedWeight) PalletName() string {
+func (csuw CallSudoUncheckedWeight) PalletName() string {
 	return PalletName
 }
 
-func (this CallSudoUncheckedWeight) CallIndex() uint8 {
+func (csuw CallSudoUncheckedWeight) CallIndex() uint8 {
 	return 1
 }
 
-func (this CallSudoUncheckedWeight) CallName() string {
+func (csuw CallSudoUncheckedWeight) CallName() string {
 	return "sudo_unchecked_weight"
 }
 
@@ -59,18 +59,18 @@ type CallSudoAs struct {
 	Call prim.Call
 }
 
-func (this CallSudoAs) PalletIndex() uint8 {
+func (csa CallSudoAs) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSudoAs) PalletName() string {
+func (csa CallSudoAs) PalletName() string {
 	return PalletName
 }
 
-func (this CallSudoAs) CallIndex() uint8 {
+func (csa CallSudoAs) CallIndex() uint8 {
 	return 3
 }
 
-func (this CallSudoAs) CallName() string {
+func (csa CallSudoAs) CallName() string {
 	return "sudo_as"
 }

--- a/metadata/pallets/sudo/events.go
+++ b/metadata/pallets/sudo/events.go
@@ -9,19 +9,19 @@ type EventSudid struct {
 	SudoResult metadata.DispatchResult
 }
 
-func (this EventSudid) PalletIndex() uint8 {
+func (es EventSudid) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventSudid) PalletName() string {
+func (es EventSudid) PalletName() string {
 	return PalletName
 }
 
-func (this EventSudid) EventIndex() uint8 {
+func (es EventSudid) EventIndex() uint8 {
 	return 0
 }
 
-func (this EventSudid) EventName() string {
+func (es EventSudid) EventName() string {
 	return "Sudid"
 }
 
@@ -30,18 +30,18 @@ type EventSudoAsDone struct {
 	SudoResult metadata.DispatchResult
 }
 
-func (this EventSudoAsDone) PalletIndex() uint8 {
+func (esad EventSudoAsDone) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventSudoAsDone) PalletName() string {
+func (esad EventSudoAsDone) PalletName() string {
 	return PalletName
 }
 
-func (this EventSudoAsDone) EventIndex() uint8 {
+func (esad EventSudoAsDone) EventIndex() uint8 {
 	return 3
 }
 
-func (this EventSudoAsDone) EventName() string {
+func (esad EventSudoAsDone) EventName() string {
 	return "SudoAsDone"
 }

--- a/metadata/pallets/sudo/storage.go
+++ b/metadata/pallets/sudo/storage.go
@@ -9,14 +9,14 @@ import (
 type StorageKeyValue = prim.AccountId
 type StorageKey struct{}
 
-func (this *StorageKey) PalletName() string {
+func (sk *StorageKey) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageKey) StorageName() string {
+func (sk *StorageKey) StorageName() string {
 	return "Key"
 }
 
-func (this *StorageKey) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageKeyValue], error) {
-	return GenericFetch[StorageKeyValue](blockStorage, this)
+func (sk *StorageKey) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageKeyValue], error) {
+	return GenericFetch[StorageKeyValue](blockStorage, sk)
 }

--- a/metadata/pallets/system/calls.go
+++ b/metadata/pallets/system/calls.go
@@ -1,25 +1,23 @@
 package system
 
-import ()
-
 // Make some on-chain remark.
 type CallRemark struct {
 	Remark []byte
 }
 
-func (this CallRemark) PalletIndex() uint8 {
+func (cr CallRemark) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallRemark) PalletName() string {
+func (cr CallRemark) PalletName() string {
 	return PalletName
 }
 
-func (this CallRemark) CallIndex() uint8 {
+func (cr CallRemark) CallIndex() uint8 {
 	return 0
 }
 
-func (this CallRemark) CallName() string {
+func (cr CallRemark) CallName() string {
 	return "remark"
 }
 
@@ -28,18 +26,18 @@ type CallRemarkWithEvent struct {
 	Remark []byte
 }
 
-func (this CallRemarkWithEvent) PalletIndex() uint8 {
+func (crwe CallRemarkWithEvent) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallRemarkWithEvent) PalletName() string {
+func (crwe CallRemarkWithEvent) PalletName() string {
 	return PalletName
 }
 
-func (this CallRemarkWithEvent) CallIndex() uint8 {
+func (crwe CallRemarkWithEvent) CallIndex() uint8 {
 	return 7
 }
 
-func (this CallRemarkWithEvent) CallName() string {
+func (crwe CallRemarkWithEvent) CallName() string {
 	return "remark_with_event"
 }

--- a/metadata/pallets/system/events.go
+++ b/metadata/pallets/system/events.go
@@ -10,19 +10,19 @@ type EventExtrinsicSuccess struct {
 	DispatchInfo meta.DispatchInfo
 }
 
-func (this EventExtrinsicSuccess) PalletIndex() uint8 {
+func (ees EventExtrinsicSuccess) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventExtrinsicSuccess) PalletName() string {
+func (ees EventExtrinsicSuccess) PalletName() string {
 	return PalletName
 }
 
-func (this EventExtrinsicSuccess) EventIndex() uint8 {
+func (ees EventExtrinsicSuccess) EventIndex() uint8 {
 	return 0
 }
 
-func (this EventExtrinsicSuccess) EventName() string {
+func (ees EventExtrinsicSuccess) EventName() string {
 	return "ExtrinsicSuccess"
 }
 
@@ -32,19 +32,19 @@ type EventExtrinsicFailed struct {
 	DispatchInfo  meta.DispatchInfo
 }
 
-func (this EventExtrinsicFailed) PalletIndex() uint8 {
+func (eef EventExtrinsicFailed) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventExtrinsicFailed) PalletName() string {
+func (eef EventExtrinsicFailed) PalletName() string {
 	return PalletName
 }
 
-func (this EventExtrinsicFailed) EventIndex() uint8 {
+func (eef EventExtrinsicFailed) EventIndex() uint8 {
 	return 1
 }
 
-func (this EventExtrinsicFailed) EventName() string {
+func (eef EventExtrinsicFailed) EventName() string {
 	return "ExtrinsicFailed"
 }
 
@@ -53,19 +53,19 @@ type EventNewAccount struct {
 	Account primitives.AccountId
 }
 
-func (this EventNewAccount) PalletIndex() uint8 {
+func (ena EventNewAccount) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventNewAccount) PalletName() string {
+func (ena EventNewAccount) PalletName() string {
 	return PalletName
 }
 
-func (this EventNewAccount) EventIndex() uint8 {
+func (ena EventNewAccount) EventIndex() uint8 {
 	return 3
 }
 
-func (this EventNewAccount) EventName() string {
+func (ena EventNewAccount) EventName() string {
 	return "NewAccount"
 }
 
@@ -74,19 +74,19 @@ type EventKilledAccount struct {
 	Account primitives.AccountId
 }
 
-func (this EventKilledAccount) PalletIndex() uint8 {
+func (eka EventKilledAccount) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventKilledAccount) PalletName() string {
+func (eka EventKilledAccount) PalletName() string {
 	return PalletName
 }
 
-func (this EventKilledAccount) EventIndex() uint8 {
+func (eka EventKilledAccount) EventIndex() uint8 {
 	return 4
 }
 
-func (this EventKilledAccount) EventName() string {
+func (eka EventKilledAccount) EventName() string {
 	return "KilledAccount"
 }
 
@@ -96,18 +96,18 @@ type EventRemarked struct {
 	Hash   primitives.H256
 }
 
-func (this EventRemarked) PalletIndex() uint8 {
+func (er EventRemarked) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventRemarked) PalletName() string {
+func (er EventRemarked) PalletName() string {
 	return PalletName
 }
 
-func (this EventRemarked) EventIndex() uint8 {
+func (er EventRemarked) EventIndex() uint8 {
 	return 5
 }
 
-func (this EventRemarked) EventName() string {
+func (er EventRemarked) EventName() string {
 	return "Remarked"
 }

--- a/metadata/pallets/system/storage.go
+++ b/metadata/pallets/system/storage.go
@@ -17,25 +17,25 @@ type StorageAccount struct {
 	AccountData AccountData
 }
 
-func (this *StorageAccount) PalletName() string {
+func (sa *StorageAccount) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageAccount) StorageName() string {
+func (sa *StorageAccount) StorageName() string {
 	return "Account"
 }
 
-func (this *StorageAccount) MapKeyHasher() uint8 {
+func (sa *StorageAccount) MapKeyHasher() uint8 {
 	return Blake2_128ConcatHasher
 }
 
-func (this *StorageAccount) Fetch(blockStorage interfaces.BlockStorageT, key StorageAccountKey) (StorageAccountEntry, error) {
-	val, err := GenericMapFetch[StorageAccount](blockStorage, key, this)
+func (sa *StorageAccount) Fetch(blockStorage interfaces.BlockStorageT, key StorageAccountKey) (StorageAccountEntry, error) {
+	val, err := GenericMapFetch[StorageAccount](blockStorage, key, sa)
 	return val.Unwrap(), err
 }
 
-func (this *StorageAccount) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageAccountEntry, error) {
-	return GenericMapKeysFetch[StorageAccount, StorageAccountKey](blockStorage, this)
+func (sa *StorageAccount) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageAccountEntry, error) {
+	return GenericMapKeysFetch[StorageAccount, StorageAccountKey](blockStorage, sa)
 }
 
 //
@@ -49,24 +49,24 @@ type StorageBlockHash struct {
 	Value prim.H256
 }
 
-func (this *StorageBlockHash) PalletName() string {
+func (sbh *StorageBlockHash) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageBlockHash) StorageName() string {
+func (sbh *StorageBlockHash) StorageName() string {
 	return "BlockHash"
 }
 
-func (this *StorageBlockHash) MapKeyHasher() uint8 {
+func (sbh *StorageBlockHash) MapKeyHasher() uint8 {
 	return Twox64ConcatHasher
 }
 
-func (this *StorageBlockHash) Fetch(blockStorage interfaces.BlockStorageT, key StorageBlockHashKey) (prim.Option[StorageBlockHashEntry], error) {
-	return GenericMapFetch[StorageBlockHash](blockStorage, key, this)
+func (sbh *StorageBlockHash) Fetch(blockStorage interfaces.BlockStorageT, key StorageBlockHashKey) (prim.Option[StorageBlockHashEntry], error) {
+	return GenericMapFetch[StorageBlockHash](blockStorage, key, sbh)
 }
 
-func (this *StorageBlockHash) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageBlockHashEntry, error) {
-	return GenericMapKeysFetch[StorageBlockHash, StorageBlockHashKey](blockStorage, this)
+func (sbh *StorageBlockHash) FetchAll(blockStorage interfaces.BlockStorageT) ([]StorageBlockHashEntry, error) {
+	return GenericMapKeysFetch[StorageBlockHash, StorageBlockHashKey](blockStorage, sbh)
 }
 
 //
@@ -79,16 +79,16 @@ type StorageBlockWeight struct {
 	Mandatory   Weight
 }
 
-func (this *StorageBlockWeight) PalletName() string {
+func (sbw *StorageBlockWeight) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageBlockWeight) StorageName() string {
+func (sbw *StorageBlockWeight) StorageName() string {
 	return "BlockWeight"
 }
 
-func (this *StorageBlockWeight) Fetch(blockStorage interfaces.BlockStorageT) (StorageBlockWeight, error) {
-	return GenericFetchDefault[StorageBlockWeight](blockStorage, this)
+func (sbw *StorageBlockWeight) Fetch(blockStorage interfaces.BlockStorageT) (StorageBlockWeight, error) {
+	return GenericFetchDefault[StorageBlockWeight](blockStorage, sbw)
 }
 
 //
@@ -102,16 +102,16 @@ type StorageDynamicBlockLength struct {
 	ChunkSize uint32 `scale:"compact"`
 }
 
-func (this *StorageDynamicBlockLength) PalletName() string {
+func (sdbl *StorageDynamicBlockLength) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageDynamicBlockLength) StorageName() string {
+func (sdbl *StorageDynamicBlockLength) StorageName() string {
 	return "DynamicBlockLength"
 }
 
-func (this *StorageDynamicBlockLength) Fetch(blockStorage interfaces.BlockStorageT) (StorageDynamicBlockLength, error) {
-	val, err := GenericFetch[StorageDynamicBlockLength](blockStorage, this)
+func (sdbl *StorageDynamicBlockLength) Fetch(blockStorage interfaces.BlockStorageT) (StorageDynamicBlockLength, error) {
+	val, err := GenericFetch[StorageDynamicBlockLength](blockStorage, sdbl)
 
 	// TODO Fallback might not be correct.
 	// Fallback: 0x00003c0000005000000050000104010480
@@ -125,16 +125,16 @@ func (this *StorageDynamicBlockLength) Fetch(blockStorage interfaces.BlockStorag
 type StorageEventCountValue = uint32
 type StorageEventCount struct{}
 
-func (this *StorageEventCount) PalletName() string {
+func (sec *StorageEventCount) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageEventCount) StorageName() string {
+func (sec *StorageEventCount) StorageName() string {
 	return "EventCount"
 }
 
-func (this *StorageEventCount) Fetch(blockStorage interfaces.BlockStorageT) (StorageEventCountValue, error) {
-	return GenericFetchDefault[StorageEventCountValue](blockStorage, this)
+func (sec *StorageEventCount) Fetch(blockStorage interfaces.BlockStorageT) (StorageEventCountValue, error) {
+	return GenericFetchDefault[StorageEventCountValue](blockStorage, sec)
 }
 
 //
@@ -144,16 +144,16 @@ func (this *StorageEventCount) Fetch(blockStorage interfaces.BlockStorageT) (Sto
 type StorageExtrinsicCountValue = uint32
 type StorageExtrinsicCount struct{}
 
-func (this *StorageExtrinsicCount) PalletName() string {
+func (sec *StorageExtrinsicCount) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageExtrinsicCount) StorageName() string {
+func (sec *StorageExtrinsicCount) StorageName() string {
 	return "ExtrinsicCount"
 }
 
-func (this *StorageExtrinsicCount) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageExtrinsicCountValue], error) {
-	return GenericFetch[StorageExtrinsicCountValue](blockStorage, this)
+func (sec *StorageExtrinsicCount) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StorageExtrinsicCountValue], error) {
+	return GenericFetch[StorageExtrinsicCountValue](blockStorage, sec)
 }
 
 //
@@ -163,16 +163,16 @@ func (this *StorageExtrinsicCount) Fetch(blockStorage interfaces.BlockStorageT) 
 type StorageNumberValue = uint32
 type StorageNumber struct{}
 
-func (this *StorageNumber) PalletName() string {
+func (sn *StorageNumber) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageNumber) StorageName() string {
+func (sn *StorageNumber) StorageName() string {
 	return "Number"
 }
 
-func (this *StorageNumber) Fetch(blockStorage interfaces.BlockStorageT) (StorageNumberValue, error) {
-	return GenericFetchDefault[StorageNumberValue](blockStorage, this)
+func (sn *StorageNumber) Fetch(blockStorage interfaces.BlockStorageT) (StorageNumberValue, error) {
+	return GenericFetchDefault[StorageNumberValue](blockStorage, sn)
 }
 
 //
@@ -182,14 +182,14 @@ func (this *StorageNumber) Fetch(blockStorage interfaces.BlockStorageT) (Storage
 type StorageParentHashValue = prim.H256
 type StorageParentHash struct{}
 
-func (this *StorageParentHash) PalletName() string {
+func (sph *StorageParentHash) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageParentHash) StorageName() string {
+func (sph *StorageParentHash) StorageName() string {
 	return "ParentHash"
 }
 
-func (this *StorageParentHash) Fetch(blockStorage interfaces.BlockStorageT) (StorageParentHashValue, error) {
-	return GenericFetchDefault[StorageParentHashValue](blockStorage, this)
+func (sph *StorageParentHash) Fetch(blockStorage interfaces.BlockStorageT) (StorageParentHashValue, error) {
+	return GenericFetchDefault[StorageParentHashValue](blockStorage, sph)
 }

--- a/metadata/pallets/technical_committee/storage.go
+++ b/metadata/pallets/technical_committee/storage.go
@@ -9,16 +9,16 @@ import (
 type StorageMembersValue = []prim.AccountId
 type StorageMembers struct{}
 
-func (this *StorageMembers) PalletName() string {
+func (sm *StorageMembers) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageMembers) StorageName() string {
+func (sm *StorageMembers) StorageName() string {
 	return "Members"
 }
 
-func (this *StorageMembers) Fetch(blockStorage interfaces.BlockStorageT) (StorageMembersValue, error) {
-	val, err := GenericFetch[StorageMembersValue](blockStorage, this)
+func (sm *StorageMembers) Fetch(blockStorage interfaces.BlockStorageT) (StorageMembersValue, error) {
+	val, err := GenericFetch[StorageMembersValue](blockStorage, sm)
 	return val.UnwrapOr(StorageMembersValue{}), err
 }
 
@@ -29,16 +29,16 @@ func (this *StorageMembers) Fetch(blockStorage interfaces.BlockStorageT) (Storag
 type StoragePrimeValue = prim.AccountId
 type StoragePrime struct{}
 
-func (this *StoragePrime) PalletName() string {
+func (sp *StoragePrime) PalletName() string {
 	return PalletName
 }
 
-func (this *StoragePrime) StorageName() string {
+func (sp *StoragePrime) StorageName() string {
 	return "Prime"
 }
 
-func (this *StoragePrime) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StoragePrimeValue], error) {
-	return GenericFetch[StoragePrimeValue](blockStorage, this)
+func (sp *StoragePrime) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StoragePrimeValue], error) {
+	return GenericFetch[StoragePrimeValue](blockStorage, sp)
 }
 
 //
@@ -48,16 +48,16 @@ func (this *StoragePrime) Fetch(blockStorage interfaces.BlockStorageT) (prim.Opt
 type StorageProposalCountValue = uint32
 type StorageProposalCount struct{}
 
-func (this *StorageProposalCount) PalletName() string {
+func (spc *StorageProposalCount) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageProposalCount) StorageName() string {
+func (spc *StorageProposalCount) StorageName() string {
 	return "ProposalCount"
 }
 
-func (this *StorageProposalCount) Fetch(blockStorage interfaces.BlockStorageT) (StorageProposalCountValue, error) {
-	return GenericFetchDefault[StorageProposalCountValue](blockStorage, this)
+func (spc *StorageProposalCount) Fetch(blockStorage interfaces.BlockStorageT) (StorageProposalCountValue, error) {
+	return GenericFetchDefault[StorageProposalCountValue](blockStorage, spc)
 }
 
 //
@@ -67,14 +67,14 @@ func (this *StorageProposalCount) Fetch(blockStorage interfaces.BlockStorageT) (
 type StorageProposalsValue = []prim.H256
 type StorageProposals struct{}
 
-func (this *StorageProposals) PalletName() string {
+func (sp *StorageProposals) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageProposals) StorageName() string {
+func (sp *StorageProposals) StorageName() string {
 	return "Proposals"
 }
 
-func (this *StorageProposals) Fetch(blockStorage interfaces.BlockStorageT) (StorageProposalsValue, error) {
-	return GenericFetchDefault[StorageProposalsValue](blockStorage, this)
+func (sp *StorageProposals) Fetch(blockStorage interfaces.BlockStorageT) (StorageProposalsValue, error) {
+	return GenericFetchDefault[StorageProposalsValue](blockStorage, sp)
 }

--- a/metadata/pallets/timestamp/storage.go
+++ b/metadata/pallets/timestamp/storage.go
@@ -8,16 +8,16 @@ import (
 type StorageNowValue = uint64
 type StorageNow struct{}
 
-func (this *StorageNow) PalletName() string {
+func (sn *StorageNow) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageNow) StorageName() string {
+func (sn *StorageNow) StorageName() string {
 	return "Now"
 }
 
-func (this *StorageNow) Fetch(blockStorage interfaces.BlockStorageT) (StorageNowValue, error) {
-	val, err := GenericFetch[StorageNowValue](blockStorage, this)
+func (sn *StorageNow) Fetch(blockStorage interfaces.BlockStorageT) (StorageNowValue, error) {
+	val, err := GenericFetch[StorageNowValue](blockStorage, sn)
 	if err != nil {
 		return 0, err
 	}

--- a/metadata/pallets/transaction_payment/events.go
+++ b/metadata/pallets/transaction_payment/events.go
@@ -13,18 +13,18 @@ type EventTransactionFeePaid struct {
 	Tip       uint128.Uint128
 }
 
-func (this EventTransactionFeePaid) PalletIndex() uint8 {
+func (etfp EventTransactionFeePaid) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventTransactionFeePaid) PalletName() string {
+func (etfp EventTransactionFeePaid) PalletName() string {
 	return PalletName
 }
 
-func (this EventTransactionFeePaid) EventIndex() uint8 {
+func (etfp EventTransactionFeePaid) EventIndex() uint8 {
 	return 0
 }
 
-func (this EventTransactionFeePaid) EventName() string {
+func (etfp EventTransactionFeePaid) EventName() string {
 	return "TransactionFeePaid"
 }

--- a/metadata/pallets/transaction_payment/storage.go
+++ b/metadata/pallets/transaction_payment/storage.go
@@ -8,16 +8,16 @@ import (
 type StorageNextFeeMultiplierValue = Balance
 type StorageNextFeeMultiplier struct{}
 
-func (this *StorageNextFeeMultiplier) PalletName() string {
+func (snfm *StorageNextFeeMultiplier) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageNextFeeMultiplier) StorageName() string {
+func (snfm *StorageNextFeeMultiplier) StorageName() string {
 	return "NextFeeMultiplier"
 }
 
-func (this *StorageNextFeeMultiplier) Fetch(blockStorage interfaces.BlockStorageT) (StorageNextFeeMultiplierValue, error) {
-	val, err := GenericFetch[StorageNextFeeMultiplierValue](blockStorage, this)
+func (snfm *StorageNextFeeMultiplier) Fetch(blockStorage interfaces.BlockStorageT) (StorageNextFeeMultiplierValue, error) {
+	val, err := GenericFetch[StorageNextFeeMultiplierValue](blockStorage, snfm)
 	if err != nil {
 		return StorageNextFeeMultiplierValue{}, err
 	}

--- a/metadata/pallets/treasury_committee/storage.go
+++ b/metadata/pallets/treasury_committee/storage.go
@@ -9,16 +9,16 @@ import (
 type StorageMembersValue = []prim.AccountId
 type StorageMembers struct{}
 
-func (this *StorageMembers) PalletName() string {
+func (sm *StorageMembers) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageMembers) StorageName() string {
+func (sm *StorageMembers) StorageName() string {
 	return "Members"
 }
 
-func (this *StorageMembers) Fetch(blockStorage interfaces.BlockStorageT) (StorageMembersValue, error) {
-	val, err := GenericFetch[StorageMembersValue](blockStorage, this)
+func (sm *StorageMembers) Fetch(blockStorage interfaces.BlockStorageT) (StorageMembersValue, error) {
+	val, err := GenericFetch[StorageMembersValue](blockStorage, sm)
 	return val.UnwrapOr(StorageMembersValue{}), err
 }
 
@@ -29,16 +29,16 @@ func (this *StorageMembers) Fetch(blockStorage interfaces.BlockStorageT) (Storag
 type StoragePrimeValue = prim.AccountId
 type StoragePrime struct{}
 
-func (this *StoragePrime) PalletName() string {
+func (sp *StoragePrime) PalletName() string {
 	return PalletName
 }
 
-func (this *StoragePrime) StorageName() string {
+func (sp *StoragePrime) StorageName() string {
 	return "Prime"
 }
 
-func (this *StoragePrime) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StoragePrimeValue], error) {
-	return GenericFetch[StoragePrimeValue](blockStorage, this)
+func (sp *StoragePrime) Fetch(blockStorage interfaces.BlockStorageT) (prim.Option[StoragePrimeValue], error) {
+	return GenericFetch[StoragePrimeValue](blockStorage, sp)
 }
 
 //
@@ -48,16 +48,16 @@ func (this *StoragePrime) Fetch(blockStorage interfaces.BlockStorageT) (prim.Opt
 type StorageProposalCountValue = uint32
 type StorageProposalCount struct{}
 
-func (this *StorageProposalCount) PalletName() string {
+func (spc *StorageProposalCount) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageProposalCount) StorageName() string {
+func (spc *StorageProposalCount) StorageName() string {
 	return "ProposalCount"
 }
 
-func (this *StorageProposalCount) Fetch(blockStorage interfaces.BlockStorageT) (StorageProposalCountValue, error) {
-	return GenericFetchDefault[StorageProposalCountValue](blockStorage, this)
+func (spc *StorageProposalCount) Fetch(blockStorage interfaces.BlockStorageT) (StorageProposalCountValue, error) {
+	return GenericFetchDefault[StorageProposalCountValue](blockStorage, spc)
 }
 
 //
@@ -67,14 +67,14 @@ func (this *StorageProposalCount) Fetch(blockStorage interfaces.BlockStorageT) (
 type StorageProposalsValue = []prim.H256
 type StorageProposals struct{}
 
-func (this *StorageProposals) PalletName() string {
+func (sp *StorageProposals) PalletName() string {
 	return PalletName
 }
 
-func (this *StorageProposals) StorageName() string {
+func (sp *StorageProposals) StorageName() string {
 	return "Proposals"
 }
 
-func (this *StorageProposals) Fetch(blockStorage interfaces.BlockStorageT) (StorageProposalsValue, error) {
-	return GenericFetchDefault[StorageProposalsValue](blockStorage, this)
+func (sp *StorageProposals) Fetch(blockStorage interfaces.BlockStorageT) (StorageProposalsValue, error) {
+	return GenericFetchDefault[StorageProposalsValue](blockStorage, sp)
 }

--- a/metadata/pallets/utility/calls.go
+++ b/metadata/pallets/utility/calls.go
@@ -12,28 +12,28 @@ type CallBatch struct {
 	Calls []prim.Call
 }
 
-func (this CallBatch) PalletIndex() uint8 {
+func (c CallBatch) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallBatch) PalletName() string {
+func (c CallBatch) PalletName() string {
 	return PalletName
 }
 
-func (this CallBatch) CallIndex() uint8 {
+func (c CallBatch) CallIndex() uint8 {
 	return 0
 }
 
-func (this CallBatch) CallName() string {
+func (c CallBatch) CallName() string {
 	return "batch"
 }
 
-func (this *CallBatch) AddCall(value prim.Call) {
-	this.Calls = append(this.Calls, value)
+func (c *CallBatch) AddCall(value prim.Call) {
+	c.Calls = append(c.Calls, value)
 }
 
-func (this *CallBatch) AddPayload(value metadata.Payload) {
-	this.Calls = append(this.Calls, value.Call)
+func (c *CallBatch) AddPayload(value metadata.Payload) {
+	c.Calls = append(c.Calls, value.Call)
 }
 
 // Send a call through an indexed pseudonym of the sender.
@@ -50,19 +50,19 @@ type CallAsDerivate struct {
 	Call  prim.Call
 }
 
-func (this CallAsDerivate) PalletIndex() uint8 {
+func (c CallAsDerivate) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallAsDerivate) PalletName() string {
+func (c CallAsDerivate) PalletName() string {
 	return PalletName
 }
 
-func (this CallAsDerivate) CallIndex() uint8 {
+func (c CallAsDerivate) CallIndex() uint8 {
 	return 1
 }
 
-func (this CallAsDerivate) CallName() string {
+func (c CallAsDerivate) CallName() string {
 	return "AsDerivate"
 }
 
@@ -74,19 +74,19 @@ type CallBatchAll struct {
 	Calls []prim.Call
 }
 
-func (this CallBatchAll) PalletIndex() uint8 {
+func (c CallBatchAll) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallBatchAll) PalletName() string {
+func (c CallBatchAll) PalletName() string {
 	return PalletName
 }
 
-func (this CallBatchAll) CallIndex() uint8 {
+func (c CallBatchAll) CallIndex() uint8 {
 	return 2
 }
 
-func (this CallBatchAll) CallName() string {
+func (c CallBatchAll) CallName() string {
 	return "BatchAll"
 }
 
@@ -98,18 +98,18 @@ type CallForceBatch struct {
 	Calls []prim.Call
 }
 
-func (this CallForceBatch) PalletIndex() uint8 {
+func (c CallForceBatch) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallForceBatch) PalletName() string {
+func (c CallForceBatch) PalletName() string {
 	return PalletName
 }
 
-func (this CallForceBatch) CallIndex() uint8 {
+func (c CallForceBatch) CallIndex() uint8 {
 	return 4
 }
 
-func (this CallForceBatch) CallName() string {
+func (c CallForceBatch) CallName() string {
 	return "ForceBatch"
 }

--- a/metadata/pallets/utility/events.go
+++ b/metadata/pallets/utility/events.go
@@ -10,76 +10,76 @@ type EventBatchInterrupted struct {
 	Error metadata.DispatchError
 }
 
-func (this EventBatchInterrupted) PalletIndex() uint8 {
+func (ebi EventBatchInterrupted) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventBatchInterrupted) PalletName() string {
+func (ebi EventBatchInterrupted) PalletName() string {
 	return PalletName
 }
 
-func (this EventBatchInterrupted) EventIndex() uint8 {
+func (ebi EventBatchInterrupted) EventIndex() uint8 {
 	return 0
 }
 
-func (this EventBatchInterrupted) EventName() string {
+func (ebi EventBatchInterrupted) EventName() string {
 	return "BatchInterrupted"
 }
 
 // Batch of dispatches completed fully with no error.
 type EventBatchCompleted struct{}
 
-func (this EventBatchCompleted) PalletIndex() uint8 {
+func (ebc EventBatchCompleted) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventBatchCompleted) PalletName() string {
+func (ebc EventBatchCompleted) PalletName() string {
 	return PalletName
 }
 
-func (this EventBatchCompleted) EventIndex() uint8 {
+func (ebc EventBatchCompleted) EventIndex() uint8 {
 	return 1
 }
 
-func (this EventBatchCompleted) EventName() string {
+func (ebc EventBatchCompleted) EventName() string {
 	return "BatchCompleted"
 }
 
 // Batch of dispatches completed but has errors.
 type EventBatchCompletedWithErrors struct{}
 
-func (this EventBatchCompletedWithErrors) PalletIndex() uint8 {
+func (ebcwe EventBatchCompletedWithErrors) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventBatchCompletedWithErrors) PalletName() string {
+func (ebcwe EventBatchCompletedWithErrors) PalletName() string {
 	return PalletName
 }
 
-func (this EventBatchCompletedWithErrors) EventIndex() uint8 {
+func (ebcwe EventBatchCompletedWithErrors) EventIndex() uint8 {
 	return 2
 }
 
-func (this EventBatchCompletedWithErrors) EventName() string {
+func (ebcwe EventBatchCompletedWithErrors) EventName() string {
 	return "BatchCompletedWithErrors"
 }
 
 // A single item within a Batch of dispatches has completed with no error.
 type EventItemCompleted struct{}
 
-func (this EventItemCompleted) PalletIndex() uint8 {
+func (eic EventItemCompleted) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventItemCompleted) PalletName() string {
+func (eic EventItemCompleted) PalletName() string {
 	return PalletName
 }
 
-func (this EventItemCompleted) EventIndex() uint8 {
+func (eic EventItemCompleted) EventIndex() uint8 {
 	return 3
 }
 
-func (this EventItemCompleted) EventName() string {
+func (eic EventItemCompleted) EventName() string {
 	return "ItemCompleted"
 }
 
@@ -88,19 +88,19 @@ type EventItemFailed struct {
 	Error metadata.DispatchError
 }
 
-func (this EventItemFailed) PalletIndex() uint8 {
+func (eif EventItemFailed) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventItemFailed) PalletName() string {
+func (eif EventItemFailed) PalletName() string {
 	return PalletName
 }
 
-func (this EventItemFailed) EventIndex() uint8 {
+func (eif EventItemFailed) EventIndex() uint8 {
 	return 4
 }
 
-func (this EventItemFailed) EventName() string {
+func (eif EventItemFailed) EventName() string {
 	return "ItemFailed"
 }
 
@@ -109,18 +109,18 @@ type EventDispatchedAs struct {
 	Result metadata.DispatchResult
 }
 
-func (this EventDispatchedAs) PalletIndex() uint8 {
+func (eda EventDispatchedAs) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this EventDispatchedAs) PalletName() string {
+func (eda EventDispatchedAs) PalletName() string {
 	return PalletName
 }
 
-func (this EventDispatchedAs) EventIndex() uint8 {
+func (eda EventDispatchedAs) EventIndex() uint8 {
 	return 5
 }
 
-func (this EventDispatchedAs) EventName() string {
+func (eda EventDispatchedAs) EventName() string {
 	return "DispatchedAs"
 }

--- a/metadata/pallets/vector/calls.go
+++ b/metadata/pallets/vector/calls.go
@@ -13,19 +13,19 @@ type CallFulfillCall struct {
 	Slot       uint64 `scale:"compact"`
 }
 
-func (this CallFulfillCall) PalletIndex() uint8 {
+func (cfc CallFulfillCall) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallFulfillCall) PalletName() string {
+func (cfc CallFulfillCall) PalletName() string {
 	return PalletName
 }
 
-func (this CallFulfillCall) CallIndex() uint8 {
+func (cfc CallFulfillCall) CallIndex() uint8 {
 	return 0
 }
 
-func (this CallFulfillCall) CallName() string {
+func (cfc CallFulfillCall) CallName() string {
 	return "fulfill_call"
 }
 
@@ -36,19 +36,19 @@ type CallExecute struct {
 	StorageProof []byte
 }
 
-func (this CallExecute) PalletIndex() uint8 {
+func (ce CallExecute) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallExecute) PalletName() string {
+func (ce CallExecute) PalletName() string {
 	return PalletName
 }
 
-func (this CallExecute) CallIndex() uint8 {
+func (ce CallExecute) CallIndex() uint8 {
 	return 1
 }
 
-func (this CallExecute) CallName() string {
+func (ce CallExecute) CallName() string {
 	return "execute"
 }
 
@@ -57,19 +57,19 @@ type CallSourceChainFroze struct {
 	Frozen        bool
 }
 
-func (this CallSourceChainFroze) PalletIndex() uint8 {
+func (cscf CallSourceChainFroze) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSourceChainFroze) PalletName() string {
+func (cscf CallSourceChainFroze) PalletName() string {
 	return PalletName
 }
 
-func (this CallSourceChainFroze) CallIndex() uint8 {
+func (cscf CallSourceChainFroze) CallIndex() uint8 {
 	return 2
 }
 
-func (this CallSourceChainFroze) CallName() string {
+func (cscf CallSourceChainFroze) CallName() string {
 	return "source_chain_froze"
 }
 
@@ -82,19 +82,19 @@ type CallSendMessage struct {
 	Domain  uint32 `scale:"compact"`
 }
 
-func (this CallSendMessage) PalletIndex() uint8 {
+func (csm CallSendMessage) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSendMessage) PalletName() string {
+func (csm CallSendMessage) PalletName() string {
 	return PalletName
 }
 
-func (this CallSendMessage) CallIndex() uint8 {
+func (csm CallSendMessage) CallIndex() uint8 {
 	return 3
 }
 
-func (this CallSendMessage) CallName() string {
+func (csm CallSendMessage) CallName() string {
 	return "send_message"
 }
 
@@ -103,19 +103,19 @@ type CallSetPoseidonHash struct {
 	PoseidonHash []byte
 }
 
-func (this CallSetPoseidonHash) PalletIndex() uint8 {
+func (csph CallSetPoseidonHash) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSetPoseidonHash) PalletName() string {
+func (csph CallSetPoseidonHash) PalletName() string {
 	return PalletName
 }
 
-func (this CallSetPoseidonHash) CallIndex() uint8 {
+func (csph CallSetPoseidonHash) CallIndex() uint8 {
 	return 4
 }
 
-func (this CallSetPoseidonHash) CallName() string {
+func (csph CallSetPoseidonHash) CallName() string {
 	return "set_poseidon_hash"
 }
 
@@ -124,19 +124,19 @@ type CallSetBroadcaster struct {
 	Broadcaster       prim.H256
 }
 
-func (this CallSetBroadcaster) PalletIndex() uint8 {
+func (csb CallSetBroadcaster) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSetBroadcaster) PalletName() string {
+func (csb CallSetBroadcaster) PalletName() string {
 	return PalletName
 }
 
-func (this CallSetBroadcaster) CallIndex() uint8 {
+func (csb CallSetBroadcaster) CallIndex() uint8 {
 	return 5
 }
 
-func (this CallSetBroadcaster) CallName() string {
+func (csb CallSetBroadcaster) CallName() string {
 	return "set_broadcaster"
 }
 
@@ -144,19 +144,19 @@ type CallSetWhitelistedDomains struct {
 	Value []uint32
 }
 
-func (this CallSetWhitelistedDomains) PalletIndex() uint8 {
+func (cswd CallSetWhitelistedDomains) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSetWhitelistedDomains) PalletName() string {
+func (cswd CallSetWhitelistedDomains) PalletName() string {
 	return PalletName
 }
 
-func (this CallSetWhitelistedDomains) CallIndex() uint8 {
+func (cswd CallSetWhitelistedDomains) CallIndex() uint8 {
 	return 6
 }
 
-func (this CallSetWhitelistedDomains) CallName() string {
+func (cswd CallSetWhitelistedDomains) CallName() string {
 	return "set_whitelisted_domains"
 }
 
@@ -164,19 +164,19 @@ type CallSetConfiguration struct {
 	Value metadata.VectorConfiguration
 }
 
-func (this CallSetConfiguration) PalletIndex() uint8 {
+func (csc CallSetConfiguration) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSetConfiguration) PalletName() string {
+func (csc CallSetConfiguration) PalletName() string {
 	return PalletName
 }
 
-func (this CallSetConfiguration) CallIndex() uint8 {
+func (csc CallSetConfiguration) CallIndex() uint8 {
 	return 7
 }
 
-func (this CallSetConfiguration) CallName() string {
+func (csc CallSetConfiguration) CallName() string {
 	return "set_configuration"
 }
 
@@ -184,19 +184,19 @@ type CallSetFunctionsIds struct {
 	Value prim.Option[metadata.Tuple2[prim.H256, prim.H256]]
 }
 
-func (this CallSetFunctionsIds) PalletIndex() uint8 {
+func (csfi CallSetFunctionsIds) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSetFunctionsIds) PalletName() string {
+func (csfi CallSetFunctionsIds) PalletName() string {
 	return PalletName
 }
 
-func (this CallSetFunctionsIds) CallIndex() uint8 {
+func (csfi CallSetFunctionsIds) CallIndex() uint8 {
 	return 8
 }
 
-func (this CallSetFunctionsIds) CallName() string {
+func (csfi CallSetFunctionsIds) CallName() string {
 	return "set_function_ids"
 }
 
@@ -204,19 +204,19 @@ type CallSetStepVerificationKey struct {
 	Value prim.Option[[]byte]
 }
 
-func (this CallSetStepVerificationKey) PalletIndex() uint8 {
+func (cssvk CallSetStepVerificationKey) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSetStepVerificationKey) PalletName() string {
+func (cssvk CallSetStepVerificationKey) PalletName() string {
 	return PalletName
 }
 
-func (this CallSetStepVerificationKey) CallIndex() uint8 {
+func (cssvk CallSetStepVerificationKey) CallIndex() uint8 {
 	return 9
 }
 
-func (this CallSetStepVerificationKey) CallName() string {
+func (cssvk CallSetStepVerificationKey) CallName() string {
 	return "set_step_verification_key"
 }
 
@@ -224,19 +224,19 @@ type CallSetRotateVerificationKey struct {
 	Value prim.Option[[]byte]
 }
 
-func (this CallSetRotateVerificationKey) PalletIndex() uint8 {
+func (csrvk CallSetRotateVerificationKey) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSetRotateVerificationKey) PalletName() string {
+func (csrvk CallSetRotateVerificationKey) PalletName() string {
 	return PalletName
 }
 
-func (this CallSetRotateVerificationKey) CallIndex() uint8 {
+func (csrvk CallSetRotateVerificationKey) CallIndex() uint8 {
 	return 10
 }
 
-func (this CallSetRotateVerificationKey) CallName() string {
+func (csrvk CallSetRotateVerificationKey) CallName() string {
 	return "set_rotate_verification_key"
 }
 
@@ -244,19 +244,19 @@ type CallFailedSendMessageTxs struct {
 	FailedTxs []uint32 `scale:"compact"`
 }
 
-func (this CallFailedSendMessageTxs) PalletIndex() uint8 {
+func (cfsmt CallFailedSendMessageTxs) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallFailedSendMessageTxs) PalletName() string {
+func (cfsmt CallFailedSendMessageTxs) PalletName() string {
 	return PalletName
 }
 
-func (this CallFailedSendMessageTxs) CallIndex() uint8 {
+func (cfsmt CallFailedSendMessageTxs) CallIndex() uint8 {
 	return 11
 }
 
-func (this CallFailedSendMessageTxs) CallName() string {
+func (cfsmt CallFailedSendMessageTxs) CallName() string {
 	return "failed_send_message_txs"
 }
 
@@ -264,19 +264,19 @@ type CallSetUpdater struct {
 	Updater prim.H256
 }
 
-func (this CallSetUpdater) PalletIndex() uint8 {
+func (csu CallSetUpdater) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSetUpdater) PalletName() string {
+func (csu CallSetUpdater) PalletName() string {
 	return PalletName
 }
 
-func (this CallSetUpdater) CallIndex() uint8 {
+func (csu CallSetUpdater) CallIndex() uint8 {
 	return 12
 }
 
-func (this CallSetUpdater) CallName() string {
+func (csu CallSetUpdater) CallName() string {
 	return "set_updater"
 }
 
@@ -285,19 +285,19 @@ type CallFulfill struct {
 	PublicValues []byte
 }
 
-func (this CallFulfill) PalletIndex() uint8 {
+func (cf CallFulfill) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallFulfill) PalletName() string {
+func (cf CallFulfill) PalletName() string {
 	return PalletName
 }
 
-func (this CallFulfill) CallIndex() uint8 {
+func (cf CallFulfill) CallIndex() uint8 {
 	return 13
 }
 
-func (this CallFulfill) CallName() string {
+func (cf CallFulfill) CallName() string {
 	return "fulfill"
 }
 
@@ -305,19 +305,19 @@ type CallSetSp1VerificationKey struct {
 	Sp1Vk prim.H256
 }
 
-func (this CallSetSp1VerificationKey) PalletIndex() uint8 {
+func (c CallSetSp1VerificationKey) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSetSp1VerificationKey) PalletName() string {
+func (c CallSetSp1VerificationKey) PalletName() string {
 	return PalletName
 }
 
-func (this CallSetSp1VerificationKey) CallIndex() uint8 {
+func (c CallSetSp1VerificationKey) CallIndex() uint8 {
 	return 14
 }
 
-func (this CallSetSp1VerificationKey) CallName() string {
+func (c CallSetSp1VerificationKey) CallName() string {
 	return "set_sp1_verification_key"
 }
 
@@ -326,19 +326,19 @@ type CallSetSyncCommitteeHash struct {
 	Hash   prim.H256
 }
 
-func (this CallSetSyncCommitteeHash) PalletIndex() uint8 {
+func (csch CallSetSyncCommitteeHash) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallSetSyncCommitteeHash) PalletName() string {
+func (csch CallSetSyncCommitteeHash) PalletName() string {
 	return PalletName
 }
 
-func (this CallSetSyncCommitteeHash) CallIndex() uint8 {
+func (csch CallSetSyncCommitteeHash) CallIndex() uint8 {
 	return 15
 }
 
-func (this CallSetSyncCommitteeHash) CallName() string {
+func (csch CallSetSyncCommitteeHash) CallName() string {
 	return "set_sync_committee_hash"
 }
 
@@ -346,19 +346,19 @@ type CallEnableMock struct {
 	Value bool
 }
 
-func (this CallEnableMock) PalletIndex() uint8 {
+func (cem CallEnableMock) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallEnableMock) PalletName() string {
+func (cem CallEnableMock) PalletName() string {
 	return PalletName
 }
 
-func (this CallEnableMock) CallIndex() uint8 {
+func (cem CallEnableMock) CallIndex() uint8 {
 	return 16
 }
 
-func (this CallEnableMock) CallName() string {
+func (cem CallEnableMock) CallName() string {
 	return "enable_mock"
 }
 
@@ -366,18 +366,18 @@ type CallMockFulfill struct {
 	PublicValues []byte
 }
 
-func (this CallMockFulfill) PalletIndex() uint8 {
+func (cmf CallMockFulfill) PalletIndex() uint8 {
 	return PalletIndex
 }
 
-func (this CallMockFulfill) PalletName() string {
+func (cmf CallMockFulfill) PalletName() string {
 	return PalletName
 }
 
-func (this CallMockFulfill) CallIndex() uint8 {
+func (cmf CallMockFulfill) CallIndex() uint8 {
 	return 17
 }
 
-func (this CallMockFulfill) CallName() string {
+func (cmf CallMockFulfill) CallName() string {
 	return "mock_fulfill"
 }

--- a/metadata/payload.go
+++ b/metadata/payload.go
@@ -18,10 +18,10 @@ func NewPayload(call primitives.Call, palletName string, callName string) Payloa
 	}
 }
 
-func (this *Payload) PalletName() string {
-	return this.palletName
+func (p *Payload) PalletName() string {
+	return p.palletName
 }
 
-func (this *Payload) CallName() string {
-	return this.callName
+func (p *Payload) CallName() string {
+	return p.callName
 }

--- a/metadata/types.go
+++ b/metadata/types.go
@@ -29,16 +29,16 @@ func NewBalanceFromBigInt(value *big.Int) Balance {
 	return Balance{Value: uint128.FromBig(value)}
 }
 
-func (this Balance) String() string {
-	return this.ToHuman()
+func (bal Balance) String() string {
+	return bal.ToHuman()
 }
 
-func (this Balance) ToString() string {
-	return this.ToHuman()
+func (bal Balance) ToString() string {
+	return bal.ToHuman()
 }
 
-func (this Balance) ToHuman() string {
-	var stringValue = this.Value.String()
+func (bal Balance) ToHuman() string {
+	var stringValue = bal.Value.String()
 
 	if len(stringValue) <= 18 {
 		var result = "0."
@@ -72,64 +72,64 @@ func (this Balance) ToHuman() string {
 	return result + " Avail"
 }
 
-// Add returns this+v.
-func (this Balance) Add(v Balance) Balance {
-	return Balance{Value: this.Value.Add(v.Value)}
+// Add returns bal+v.
+func (bal Balance) Add(v Balance) Balance {
+	return Balance{Value: bal.Value.Add(v.Value)}
 }
 
-// Add64 returns this+v.
-func (this Balance) Add64(v uint64) Balance {
-	return Balance{Value: this.Value.Add64(v)}
+// Add64 returns bal+v.
+func (bal Balance) Add64(v uint64) Balance {
+	return Balance{Value: bal.Value.Add64(v)}
 }
 
-// Add128 returns this+v.
-func (this Balance) Add128(v uint128.Uint128) Balance {
-	return Balance{Value: this.Value.Add(v)}
+// Add128 returns bal+v.
+func (bal Balance) Add128(v uint128.Uint128) Balance {
+	return Balance{Value: bal.Value.Add(v)}
 }
 
-// Sub returns this-v.
-func (this Balance) Sub(v Balance) Balance {
-	return Balance{Value: this.Value.Sub(v.Value)}
+// Sub returns bal-v.
+func (bal Balance) Sub(v Balance) Balance {
+	return Balance{Value: bal.Value.Sub(v.Value)}
 }
 
-// Sub64 returns this-v.
-func (this Balance) Sub64(v uint64) Balance {
-	return Balance{Value: this.Value.Sub64(v)}
+// Sub64 returns bal-v.
+func (bal Balance) Sub64(v uint64) Balance {
+	return Balance{Value: bal.Value.Sub64(v)}
 }
 
-// Sub128 returns this-v.
-func (this Balance) Sub128(v uint128.Uint128) Balance {
-	return Balance{Value: this.Value.Sub(v)}
+// Sub128 returns bal-v.
+func (bal Balance) Sub128(v uint128.Uint128) Balance {
+	return Balance{Value: bal.Value.Sub(v)}
 }
 
-// Mul returns this*v.
-func (this Balance) Mul(v Balance) Balance {
-	return Balance{Value: this.Value.Mul(v.Value)}
+// Mul returns bal*v.
+func (bal Balance) Mul(v Balance) Balance {
+	return Balance{Value: bal.Value.Mul(v.Value)}
 }
 
-// Mul64 returns this*v.
-func (this Balance) Mul64(v uint64) Balance {
-	return Balance{Value: this.Value.Mul64(v)}
+// Mul64 returns bal*v.
+func (bal Balance) Mul64(v uint64) Balance {
+	return Balance{Value: bal.Value.Mul64(v)}
 }
 
-// Mul128 returns this*v.
-func (this Balance) Mul128(v uint128.Uint128) Balance {
-	return Balance{Value: this.Value.Mul(v)}
+// Mul128 returns bal*v.
+func (bal Balance) Mul128(v uint128.Uint128) Balance {
+	return Balance{Value: bal.Value.Mul(v)}
 }
 
-// Div returns this/v.
-func (this Balance) Div(v Balance) Balance {
-	return Balance{Value: this.Value.Div(v.Value)}
+// Div returns bal/v.
+func (bal Balance) Div(v Balance) Balance {
+	return Balance{Value: bal.Value.Div(v.Value)}
 }
 
-// Div64 returns this/v.
-func (this Balance) Div64(v uint64) Balance {
-	return Balance{Value: this.Value.Div64(v)}
+// Div64 returns bal/v.
+func (bal Balance) Div64(v uint64) Balance {
+	return Balance{Value: bal.Value.Div64(v)}
 }
 
-// Div128 returns this/v.
-func (this Balance) Div128(v uint128.Uint128) Balance {
-	return Balance{Value: this.Value.Div(v)}
+// Div128 returns bal/v.
+func (bal Balance) Div128(v uint128.Uint128) Balance {
+	return Balance{Value: bal.Value.Div(v)}
 }
 
 func removeTrailingZeros(s string) string {
@@ -164,12 +164,12 @@ type DispatchClass struct {
 	VariantIndex uint8
 }
 
-func (this DispatchClass) ToHuman() string {
-	return this.ToString()
+func (dc DispatchClass) ToHuman() string {
+	return dc.ToString()
 }
 
-func (this DispatchClass) ToString() string {
-	switch this.VariantIndex {
+func (dc DispatchClass) ToString() string {
+	switch dc.VariantIndex {
 	case 0:
 		return "Normal"
 	case 1:
@@ -181,8 +181,8 @@ func (this DispatchClass) ToString() string {
 	}
 }
 
-func (this DispatchClass) String() string {
-	return this.ToString()
+func (dc DispatchClass) String() string {
+	return dc.ToString()
 }
 
 // Do not add, remove or change any of the field members.
@@ -190,8 +190,8 @@ type Pays struct {
 	VariantIndex uint8
 }
 
-func (this Pays) ToString() string {
-	switch this.VariantIndex {
+func (pays Pays) ToString() string {
+	switch pays.VariantIndex {
 	case 0:
 		return "Yes"
 	case 1:
@@ -217,12 +217,12 @@ type DispatchError struct {
 	Transactional prim.Option[TransactionalError]
 }
 
-func (this DispatchError) ToHuman() string {
-	return this.ToString()
+func (de DispatchError) ToHuman() string {
+	return de.ToString()
 }
 
-func (this DispatchError) ToString() string {
-	switch this.VariantIndex {
+func (de DispatchError) ToString() string {
+	switch de.VariantIndex {
 	case 0:
 		return "Other"
 	case 1:
@@ -230,7 +230,7 @@ func (this DispatchError) ToString() string {
 	case 2:
 		return "BadOrigin"
 	case 3:
-		return fmt.Sprintf("Module. Index %v", this.Module.Unwrap().Index)
+		return fmt.Sprintf("Module. Index %v", de.Module.Unwrap().Index)
 	case 4:
 		return "ConsumerRemaining"
 	case 5:
@@ -238,11 +238,11 @@ func (this DispatchError) ToString() string {
 	case 6:
 		return "TooManyConsumers"
 	case 7:
-		return fmt.Sprintf("Token. %v", this.Token.Unwrap().ToHuman())
+		return fmt.Sprintf("Token. %v", de.Token.Unwrap().ToHuman())
 	case 8:
-		return fmt.Sprintf("Arithmetic. %v", this.Arithmetic.Unwrap().ToHuman())
+		return fmt.Sprintf("Arithmetic. %v", de.Arithmetic.Unwrap().ToHuman())
 	case 9:
-		return fmt.Sprintf("Transactional. %v", this.Transactional.Unwrap().ToString())
+		return fmt.Sprintf("Transactional. %v", de.Transactional.Unwrap().ToString())
 	case 10:
 		return "Exhausted"
 	case 11:
@@ -256,34 +256,34 @@ func (this DispatchError) ToString() string {
 	}
 }
 
-func (this *DispatchError) EncodeTo(dest *string) {
-	prim.Encoder.EncodeTo(this.VariantIndex, dest)
+func (de *DispatchError) EncodeTo(dest *string) {
+	prim.Encoder.EncodeTo(de.VariantIndex, dest)
 
-	if this.Module.IsSome() {
-		prim.Encoder.EncodeTo(this.Module.Unwrap(), dest)
+	if de.Module.IsSome() {
+		prim.Encoder.EncodeTo(de.Module.Unwrap(), dest)
 	}
 
-	if this.Token.IsSome() {
-		prim.Encoder.EncodeTo(this.Token.Unwrap(), dest)
+	if de.Token.IsSome() {
+		prim.Encoder.EncodeTo(de.Token.Unwrap(), dest)
 	}
 
-	if this.Arithmetic.IsSome() {
-		prim.Encoder.EncodeTo(this.Arithmetic.Unwrap(), dest)
+	if de.Arithmetic.IsSome() {
+		prim.Encoder.EncodeTo(de.Arithmetic.Unwrap(), dest)
 	}
 
-	if this.Transactional.IsSome() {
-		prim.Encoder.EncodeTo(this.Transactional.Unwrap(), dest)
+	if de.Transactional.IsSome() {
+		prim.Encoder.EncodeTo(de.Transactional.Unwrap(), dest)
 	}
 }
 
-func (this *DispatchError) Decode(decoder *prim.Decoder) error {
-	*this = DispatchError{}
+func (de *DispatchError) Decode(decoder *prim.Decoder) error {
+	*de = DispatchError{}
 
-	if err := decoder.Decode(&this.VariantIndex); err != nil {
+	if err := decoder.Decode(&de.VariantIndex); err != nil {
 		return err
 	}
 
-	switch this.VariantIndex {
+	switch de.VariantIndex {
 	case 0:
 	case 1:
 	case 2:
@@ -292,7 +292,7 @@ func (this *DispatchError) Decode(decoder *prim.Decoder) error {
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Module.Set(t)
+		de.Module.Set(t)
 	case 4:
 	case 5:
 	case 6:
@@ -301,19 +301,19 @@ func (this *DispatchError) Decode(decoder *prim.Decoder) error {
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Token.Set(t)
+		de.Token.Set(t)
 	case 8:
 		var t ArithmeticError
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Arithmetic.Set(t)
+		de.Arithmetic.Set(t)
 	case 9:
 		var t TransactionalError
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Transactional.Set(t)
+		de.Transactional.Set(t)
 	case 10:
 	case 11:
 	case 12:
@@ -336,12 +336,12 @@ type TokenError struct {
 	VariantIndex uint8
 }
 
-func (this TokenError) ToHuman() string {
-	return this.ToString()
+func (te TokenError) ToHuman() string {
+	return te.ToString()
 }
 
-func (this TokenError) ToString() string {
-	switch this.VariantIndex {
+func (te TokenError) ToString() string {
+	switch te.VariantIndex {
 	case 0:
 		return "FundsUnavailable"
 	case 1:
@@ -372,12 +372,12 @@ type ArithmeticError struct {
 	VariantIndex uint8
 }
 
-func (this ArithmeticError) ToHuman() string {
-	return this.ToString()
+func (te ArithmeticError) ToHuman() string {
+	return te.ToString()
 }
 
-func (this ArithmeticError) ToString() string {
-	switch this.VariantIndex {
+func (te ArithmeticError) ToString() string {
+	switch te.VariantIndex {
 	case 0:
 		return "Underflow"
 	case 1:
@@ -394,12 +394,12 @@ type TransactionalError struct {
 	VariantIndex uint8
 }
 
-func (this TransactionalError) ToHuman() string {
-	return this.ToString()
+func (te TransactionalError) ToHuman() string {
+	return te.ToString()
 }
 
-func (this TransactionalError) ToString() string {
-	switch this.VariantIndex {
+func (te TransactionalError) ToString() string {
+	switch te.VariantIndex {
 	case 0:
 		return "LimitReached"
 	case 1:
@@ -438,12 +438,12 @@ func NewPerbillFromU8(percent uint8) Perbill {
 	return Perbill{Value: value}
 }
 
-func (this Perbill) ToString() string {
-	return this.ToHuman()
+func (perbill Perbill) ToString() string {
+	return perbill.ToHuman()
 }
 
-func (this Perbill) ToHuman() string {
-	stringValue := strconv.FormatUint(uint64(this.Value), 10)
+func (perbill Perbill) ToHuman() string {
+	stringValue := strconv.FormatUint(uint64(perbill.Value), 10)
 
 	if len(stringValue) <= 7 {
 		addZeros := 7 - len(stringValue)
@@ -487,12 +487,12 @@ type RewardDestination struct {
 	Account      prim.Option[prim.AccountId]
 }
 
-func (this RewardDestination) ToHuman() string {
-	return this.ToString()
+func (rd RewardDestination) ToHuman() string {
+	return rd.ToString()
 }
 
-func (this RewardDestination) ToString() string {
-	switch this.VariantIndex {
+func (rd RewardDestination) ToString() string {
+	switch rd.VariantIndex {
 	case 0:
 		return "Staked"
 	case 1:
@@ -500,7 +500,7 @@ func (this RewardDestination) ToString() string {
 	case 2:
 		return "Controller"
 	case 3:
-		return fmt.Sprintf("Account: %v", this.Account.Unwrap().ToHuman())
+		return fmt.Sprintf("Account: %v", rd.Account.Unwrap().ToHuman())
 	case 4:
 		return "None"
 	default:
@@ -508,22 +508,22 @@ func (this RewardDestination) ToString() string {
 	}
 }
 
-func (this *RewardDestination) EncodeTo(dest *string) {
-	prim.Encoder.EncodeTo(this.VariantIndex, dest)
+func (rd *RewardDestination) EncodeTo(dest *string) {
+	prim.Encoder.EncodeTo(rd.VariantIndex, dest)
 
-	if this.Account.IsSome() {
-		prim.Encoder.EncodeTo(this.Account.Unwrap(), dest)
+	if rd.Account.IsSome() {
+		prim.Encoder.EncodeTo(rd.Account.Unwrap(), dest)
 	}
 }
 
-func (this *RewardDestination) Decode(decoder *prim.Decoder) error {
-	*this = RewardDestination{}
+func (rd *RewardDestination) Decode(decoder *prim.Decoder) error {
+	*rd = RewardDestination{}
 
-	if err := decoder.Decode(&this.VariantIndex); err != nil {
+	if err := decoder.Decode(&rd.VariantIndex); err != nil {
 		return err
 	}
 
-	switch this.VariantIndex {
+	switch rd.VariantIndex {
 	case 0:
 	case 1:
 	case 2:
@@ -532,7 +532,7 @@ func (this *RewardDestination) Decode(decoder *prim.Decoder) error {
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Account.Set(t)
+		rd.Account.Set(t)
 	case 4:
 	default:
 		return errors.New("Unknown RewardDestination Variant Index while Decoding")
@@ -558,44 +558,44 @@ type CommissionClaimPermission struct {
 	Account      prim.Option[prim.AccountId]
 }
 
-func (this CommissionClaimPermission) ToHuman() string {
-	return this.ToString()
+func (ccp CommissionClaimPermission) ToHuman() string {
+	return ccp.ToString()
 }
 
-func (this CommissionClaimPermission) ToString() string {
-	switch this.VariantIndex {
+func (ccp CommissionClaimPermission) ToString() string {
+	switch ccp.VariantIndex {
 	case 0:
 		return "Permissionless"
 	case 1:
-		return fmt.Sprintf("Account: %v", this.Account.Unwrap().ToHuman())
+		return fmt.Sprintf("Account: %v", ccp.Account.Unwrap().ToHuman())
 	default:
 		panic("Unknown CommissionClaimPermission Variant Index")
 	}
 }
 
-func (this *CommissionClaimPermission) EncodeTo(dest *string) {
-	prim.Encoder.EncodeTo(this.VariantIndex, dest)
+func (ccp *CommissionClaimPermission) EncodeTo(dest *string) {
+	prim.Encoder.EncodeTo(ccp.VariantIndex, dest)
 
-	if this.Account.IsSome() {
-		prim.Encoder.EncodeTo(this.Account.Unwrap(), dest)
+	if ccp.Account.IsSome() {
+		prim.Encoder.EncodeTo(ccp.Account.Unwrap(), dest)
 	}
 }
 
-func (this *CommissionClaimPermission) Decode(decoder *prim.Decoder) error {
-	*this = CommissionClaimPermission{}
+func (ccp *CommissionClaimPermission) Decode(decoder *prim.Decoder) error {
+	*ccp = CommissionClaimPermission{}
 
-	if err := decoder.Decode(&this.VariantIndex); err != nil {
+	if err := decoder.Decode(&ccp.VariantIndex); err != nil {
 		return err
 	}
 
-	switch this.VariantIndex {
+	switch ccp.VariantIndex {
 	case 0:
 	case 1:
 		var t prim.AccountId
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Account.Set(t)
+		ccp.Account.Set(t)
 	default:
 		return errors.New("Unknown RewardDestination Variant Index while Decoding")
 	}
@@ -614,12 +614,12 @@ type PoolState struct {
 	VariantIndex uint8
 }
 
-func (this PoolState) ToHuman() string {
-	return this.ToString()
+func (ps PoolState) ToHuman() string {
+	return ps.ToString()
 }
 
-func (this PoolState) ToString() string {
-	switch this.VariantIndex {
+func (ps PoolState) ToString() string {
+	switch ps.VariantIndex {
 	case 0:
 		return "Open"
 	case 1:
@@ -631,18 +631,18 @@ func (this PoolState) ToString() string {
 	}
 }
 
-func (this *PoolState) EncodeTo(dest *string) {
-	prim.Encoder.EncodeTo(this.VariantIndex, dest)
+func (ps *PoolState) EncodeTo(dest *string) {
+	prim.Encoder.EncodeTo(ps.VariantIndex, dest)
 }
 
-func (this *PoolState) Decode(decoder *prim.Decoder) error {
-	*this = PoolState{}
+func (ps *PoolState) Decode(decoder *prim.Decoder) error {
+	*ps = PoolState{}
 
-	if err := decoder.Decode(&this.VariantIndex); err != nil {
+	if err := decoder.Decode(&ps.VariantIndex); err != nil {
 		return err
 	}
 
-	switch this.VariantIndex {
+	switch ps.VariantIndex {
 	case 0:
 	case 1:
 	case 2:
@@ -670,12 +670,12 @@ type PoolClaimPermission struct {
 	VariantIndex uint8
 }
 
-func (this PoolClaimPermission) ToHuman() string {
-	return this.ToString()
+func (pcp PoolClaimPermission) ToHuman() string {
+	return pcp.ToString()
 }
 
-func (this PoolClaimPermission) ToString() string {
-	switch this.VariantIndex {
+func (pcp PoolClaimPermission) ToString() string {
+	switch pcp.VariantIndex {
 	case 0:
 		return "Permissioned"
 	case 1:
@@ -689,18 +689,18 @@ func (this PoolClaimPermission) ToString() string {
 	}
 }
 
-func (this *PoolClaimPermission) EncodeTo(dest *string) {
-	prim.Encoder.EncodeTo(this.VariantIndex, dest)
+func (pcp *PoolClaimPermission) EncodeTo(dest *string) {
+	prim.Encoder.EncodeTo(pcp.VariantIndex, dest)
 }
 
-func (this *PoolClaimPermission) Decode(decoder *prim.Decoder) error {
-	*this = PoolClaimPermission{}
+func (pcp *PoolClaimPermission) Decode(decoder *prim.Decoder) error {
+	*pcp = PoolClaimPermission{}
 
-	if err := decoder.Decode(&this.VariantIndex); err != nil {
+	if err := decoder.Decode(&pcp.VariantIndex); err != nil {
 		return err
 	}
 
-	switch this.VariantIndex {
+	switch pcp.VariantIndex {
 	case 0:
 	case 1:
 	case 2:
@@ -735,12 +735,12 @@ type Judgement struct {
 	FeePaid      prim.Option[Balance]
 }
 
-func (this Judgement) ToHuman() string {
-	return this.ToString()
+func (j Judgement) ToHuman() string {
+	return j.ToString()
 }
 
-func (this Judgement) ToString() string {
-	switch this.VariantIndex {
+func (j Judgement) ToString() string {
+	switch j.VariantIndex {
 	case 0:
 		return "Unknown"
 	case 1:
@@ -760,29 +760,29 @@ func (this Judgement) ToString() string {
 	}
 }
 
-func (this *Judgement) EncodeTo(dest *string) {
-	prim.Encoder.EncodeTo(this.VariantIndex, dest)
+func (j *Judgement) EncodeTo(dest *string) {
+	prim.Encoder.EncodeTo(j.VariantIndex, dest)
 
-	if this.FeePaid.IsSome() {
-		prim.Encoder.EncodeTo(this.FeePaid.Unwrap(), dest)
+	if j.FeePaid.IsSome() {
+		prim.Encoder.EncodeTo(j.FeePaid.Unwrap(), dest)
 	}
 }
 
-func (this *Judgement) Decode(decoder *prim.Decoder) error {
-	*this = Judgement{}
+func (j *Judgement) Decode(decoder *prim.Decoder) error {
+	*j = Judgement{}
 
-	if err := decoder.Decode(&this.VariantIndex); err != nil {
+	if err := decoder.Decode(&j.VariantIndex); err != nil {
 		return err
 	}
 
-	switch this.VariantIndex {
+	switch j.VariantIndex {
 	case 0:
 	case 1:
 		var t Balance
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.FeePaid.Set(t)
+		j.FeePaid.Set(t)
 	case 2:
 	case 3:
 	case 4:
@@ -836,472 +836,472 @@ type IdentityData struct {
 	ShaThree256  prim.Option[prim.H256]
 }
 
-func (this IdentityData) ToHuman() string {
-	return this.ToString()
+func (id IdentityData) ToHuman() string {
+	return id.ToString()
 }
 
-func (this IdentityData) ToString() string {
-	switch this.VariantIndex {
+func (id IdentityData) ToString() string {
+	switch id.VariantIndex {
 	case 0:
 		return "None"
 	case 1:
 		return "Raw0"
 	case 2:
-		v := this.Raw1.Unwrap()
+		v := id.Raw1.Unwrap()
 		return string(v[:])
 	case 3:
-		v := this.Raw2.Unwrap()
+		v := id.Raw2.Unwrap()
 		return string(v[:])
 	case 4:
-		v := this.Raw3.Unwrap()
+		v := id.Raw3.Unwrap()
 		return string(v[:])
 	case 5:
-		v := this.Raw4.Unwrap()
+		v := id.Raw4.Unwrap()
 		return string(v[:])
 	case 6:
-		v := this.Raw5.Unwrap()
+		v := id.Raw5.Unwrap()
 		return string(v[:])
 	case 7:
-		v := this.Raw6.Unwrap()
+		v := id.Raw6.Unwrap()
 		return string(v[:])
 	case 8:
-		v := this.Raw7.Unwrap()
+		v := id.Raw7.Unwrap()
 		return string(v[:])
 	case 9:
-		v := this.Raw8.Unwrap()
+		v := id.Raw8.Unwrap()
 		return string(v[:])
 	case 10:
-		v := this.Raw9.Unwrap()
+		v := id.Raw9.Unwrap()
 		return string(v[:])
 	case 11:
-		v := this.Raw10.Unwrap()
+		v := id.Raw10.Unwrap()
 		return string(v[:])
 	case 12:
-		v := this.Raw11.Unwrap()
+		v := id.Raw11.Unwrap()
 		return string(v[:])
 	case 13:
-		v := this.Raw12.Unwrap()
+		v := id.Raw12.Unwrap()
 		return string(v[:])
 	case 14:
-		v := this.Raw13.Unwrap()
+		v := id.Raw13.Unwrap()
 		return string(v[:])
 	case 15:
-		v := this.Raw14.Unwrap()
+		v := id.Raw14.Unwrap()
 		return string(v[:])
 	case 16:
-		v := this.Raw15.Unwrap()
+		v := id.Raw15.Unwrap()
 		return string(v[:])
 	case 17:
-		v := this.Raw16.Unwrap()
+		v := id.Raw16.Unwrap()
 		return string(v[:])
 	case 18:
-		v := this.Raw17.Unwrap()
+		v := id.Raw17.Unwrap()
 		return string(v[:])
 	case 19:
-		v := this.Raw18.Unwrap()
+		v := id.Raw18.Unwrap()
 		return string(v[:])
 	case 20:
-		v := this.Raw19.Unwrap()
+		v := id.Raw19.Unwrap()
 		return string(v[:])
 	case 21:
-		v := this.Raw20.Unwrap()
+		v := id.Raw20.Unwrap()
 		return string(v[:])
 	case 22:
-		v := this.Raw21.Unwrap()
+		v := id.Raw21.Unwrap()
 		return string(v[:])
 	case 23:
-		v := this.Raw22.Unwrap()
+		v := id.Raw22.Unwrap()
 		return string(v[:])
 	case 24:
-		v := this.Raw23.Unwrap()
+		v := id.Raw23.Unwrap()
 		return string(v[:])
 	case 25:
-		v := this.Raw24.Unwrap()
+		v := id.Raw24.Unwrap()
 		return string(v[:])
 	case 26:
-		v := this.Raw25.Unwrap()
+		v := id.Raw25.Unwrap()
 		return string(v[:])
 	case 27:
-		v := this.Raw26.Unwrap()
+		v := id.Raw26.Unwrap()
 		return string(v[:])
 	case 28:
-		v := this.Raw27.Unwrap()
+		v := id.Raw27.Unwrap()
 		return string(v[:])
 	case 29:
-		v := this.Raw28.Unwrap()
+		v := id.Raw28.Unwrap()
 		return string(v[:])
 	case 30:
-		v := this.Raw29.Unwrap()
+		v := id.Raw29.Unwrap()
 		return string(v[:])
 	case 31:
-		v := this.Raw30.Unwrap()
+		v := id.Raw30.Unwrap()
 		return string(v[:])
 	case 32:
-		v := this.Raw31.Unwrap()
+		v := id.Raw31.Unwrap()
 		return string(v[:])
 	case 33:
-		v := this.Raw32.Unwrap()
+		v := id.Raw32.Unwrap()
 		return string(v[:])
 	case 34:
-		v := this.BlakeTwo256.Unwrap()
+		v := id.BlakeTwo256.Unwrap()
 		return v.ToHexWith0x()
 	case 35:
-		v := this.Sha256.Unwrap()
+		v := id.Sha256.Unwrap()
 		return v.ToHexWith0x()
 	case 36:
-		v := this.Keccak256.Unwrap()
+		v := id.Keccak256.Unwrap()
 		return v.ToHexWith0x()
 	case 37:
-		v := this.ShaThree256.Unwrap()
+		v := id.ShaThree256.Unwrap()
 		return v.ToHexWith0x()
 	default:
 		panic("Unknown IdentityData Variant Index")
 	}
 }
 
-func (this *IdentityData) EncodeTo(dest *string) {
-	prim.Encoder.EncodeTo(this.VariantIndex, dest)
-	if this.Raw1.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw1.Unwrap(), dest)
+func (id *IdentityData) EncodeTo(dest *string) {
+	prim.Encoder.EncodeTo(id.VariantIndex, dest)
+	if id.Raw1.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw1.Unwrap(), dest)
 	}
-	if this.Raw2.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw2.Unwrap(), dest)
+	if id.Raw2.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw2.Unwrap(), dest)
 	}
-	if this.Raw3.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw3.Unwrap(), dest)
+	if id.Raw3.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw3.Unwrap(), dest)
 	}
-	if this.Raw4.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw4.Unwrap(), dest)
+	if id.Raw4.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw4.Unwrap(), dest)
 	}
-	if this.Raw5.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw5.Unwrap(), dest)
+	if id.Raw5.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw5.Unwrap(), dest)
 	}
-	if this.Raw6.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw6.Unwrap(), dest)
+	if id.Raw6.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw6.Unwrap(), dest)
 	}
-	if this.Raw7.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw7.Unwrap(), dest)
+	if id.Raw7.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw7.Unwrap(), dest)
 	}
-	if this.Raw8.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw8.Unwrap(), dest)
+	if id.Raw8.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw8.Unwrap(), dest)
 	}
-	if this.Raw9.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw9.Unwrap(), dest)
+	if id.Raw9.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw9.Unwrap(), dest)
 	}
-	if this.Raw10.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw10.Unwrap(), dest)
+	if id.Raw10.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw10.Unwrap(), dest)
 	}
-	if this.Raw11.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw11.Unwrap(), dest)
+	if id.Raw11.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw11.Unwrap(), dest)
 	}
-	if this.Raw12.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw12.Unwrap(), dest)
+	if id.Raw12.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw12.Unwrap(), dest)
 	}
-	if this.Raw13.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw13.Unwrap(), dest)
+	if id.Raw13.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw13.Unwrap(), dest)
 	}
-	if this.Raw14.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw14.Unwrap(), dest)
+	if id.Raw14.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw14.Unwrap(), dest)
 	}
-	if this.Raw15.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw15.Unwrap(), dest)
+	if id.Raw15.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw15.Unwrap(), dest)
 	}
-	if this.Raw16.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw16.Unwrap(), dest)
+	if id.Raw16.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw16.Unwrap(), dest)
 	}
-	if this.Raw17.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw17.Unwrap(), dest)
+	if id.Raw17.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw17.Unwrap(), dest)
 	}
-	if this.Raw18.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw18.Unwrap(), dest)
+	if id.Raw18.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw18.Unwrap(), dest)
 	}
-	if this.Raw19.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw19.Unwrap(), dest)
+	if id.Raw19.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw19.Unwrap(), dest)
 	}
-	if this.Raw20.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw20.Unwrap(), dest)
+	if id.Raw20.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw20.Unwrap(), dest)
 	}
-	if this.Raw21.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw21.Unwrap(), dest)
+	if id.Raw21.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw21.Unwrap(), dest)
 	}
-	if this.Raw22.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw22.Unwrap(), dest)
+	if id.Raw22.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw22.Unwrap(), dest)
 	}
-	if this.Raw23.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw23.Unwrap(), dest)
+	if id.Raw23.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw23.Unwrap(), dest)
 	}
-	if this.Raw24.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw24.Unwrap(), dest)
+	if id.Raw24.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw24.Unwrap(), dest)
 	}
-	if this.Raw25.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw25.Unwrap(), dest)
+	if id.Raw25.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw25.Unwrap(), dest)
 	}
-	if this.Raw26.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw26.Unwrap(), dest)
+	if id.Raw26.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw26.Unwrap(), dest)
 	}
-	if this.Raw27.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw27.Unwrap(), dest)
+	if id.Raw27.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw27.Unwrap(), dest)
 	}
-	if this.Raw28.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw28.Unwrap(), dest)
+	if id.Raw28.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw28.Unwrap(), dest)
 	}
-	if this.Raw29.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw29.Unwrap(), dest)
+	if id.Raw29.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw29.Unwrap(), dest)
 	}
-	if this.Raw30.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw30.Unwrap(), dest)
+	if id.Raw30.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw30.Unwrap(), dest)
 	}
-	if this.Raw31.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw31.Unwrap(), dest)
+	if id.Raw31.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw31.Unwrap(), dest)
 	}
-	if this.Raw32.IsSome() {
-		prim.Encoder.EncodeTo(this.Raw32.Unwrap(), dest)
+	if id.Raw32.IsSome() {
+		prim.Encoder.EncodeTo(id.Raw32.Unwrap(), dest)
 	}
-	if this.BlakeTwo256.IsSome() {
-		prim.Encoder.EncodeTo(this.BlakeTwo256.Unwrap(), dest)
+	if id.BlakeTwo256.IsSome() {
+		prim.Encoder.EncodeTo(id.BlakeTwo256.Unwrap(), dest)
 	}
-	if this.Sha256.IsSome() {
-		prim.Encoder.EncodeTo(this.Sha256.Unwrap(), dest)
+	if id.Sha256.IsSome() {
+		prim.Encoder.EncodeTo(id.Sha256.Unwrap(), dest)
 	}
-	if this.Keccak256.IsSome() {
-		prim.Encoder.EncodeTo(this.Keccak256.Unwrap(), dest)
+	if id.Keccak256.IsSome() {
+		prim.Encoder.EncodeTo(id.Keccak256.Unwrap(), dest)
 	}
-	if this.ShaThree256.IsSome() {
-		prim.Encoder.EncodeTo(this.ShaThree256.Unwrap(), dest)
+	if id.ShaThree256.IsSome() {
+		prim.Encoder.EncodeTo(id.ShaThree256.Unwrap(), dest)
 	}
 }
 
-func (this *IdentityData) Decode(decoder *prim.Decoder) error {
-	*this = IdentityData{}
+func (id *IdentityData) Decode(decoder *prim.Decoder) error {
+	*id = IdentityData{}
 
-	if err := decoder.Decode(&this.VariantIndex); err != nil {
+	if err := decoder.Decode(&id.VariantIndex); err != nil {
 		return err
 	}
 
-	switch this.VariantIndex {
+	switch id.VariantIndex {
 	case 0:
 	case 1:
 		var t [0]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw0.Set(t)
+		id.Raw0.Set(t)
 	case 2:
 		var t [1]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw1.Set(t)
+		id.Raw1.Set(t)
 	case 3:
 		var t [2]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw2.Set(t)
+		id.Raw2.Set(t)
 	case 4:
 		var t [3]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw3.Set(t)
+		id.Raw3.Set(t)
 	case 5:
 		var t [4]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw4.Set(t)
+		id.Raw4.Set(t)
 	case 6:
 		var t [5]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw5.Set(t)
+		id.Raw5.Set(t)
 	case 7:
 		var t [6]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw6.Set(t)
+		id.Raw6.Set(t)
 	case 8:
 		var t [7]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw7.Set(t)
+		id.Raw7.Set(t)
 	case 9:
 		var t [8]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw8.Set(t)
+		id.Raw8.Set(t)
 	case 10:
 		var t [9]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw9.Set(t)
+		id.Raw9.Set(t)
 	case 11:
 		var t [10]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw10.Set(t)
+		id.Raw10.Set(t)
 	case 12:
 		var t [11]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw11.Set(t)
+		id.Raw11.Set(t)
 	case 13:
 		var t [12]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw12.Set(t)
+		id.Raw12.Set(t)
 	case 14:
 		var t [13]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw13.Set(t)
+		id.Raw13.Set(t)
 	case 15:
 		var t [14]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw14.Set(t)
+		id.Raw14.Set(t)
 	case 16:
 		var t [15]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw15.Set(t)
+		id.Raw15.Set(t)
 	case 17:
 		var t [16]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw16.Set(t)
+		id.Raw16.Set(t)
 	case 18:
 		var t [17]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw17.Set(t)
+		id.Raw17.Set(t)
 	case 19:
 		var t [18]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw18.Set(t)
+		id.Raw18.Set(t)
 	case 20:
 		var t [19]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw19.Set(t)
+		id.Raw19.Set(t)
 	case 21:
 		var t [20]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw20.Set(t)
+		id.Raw20.Set(t)
 	case 22:
 		var t [21]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw21.Set(t)
+		id.Raw21.Set(t)
 	case 23:
 		var t [22]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw22.Set(t)
+		id.Raw22.Set(t)
 	case 24:
 		var t [23]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw23.Set(t)
+		id.Raw23.Set(t)
 	case 25:
 		var t [24]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw24.Set(t)
+		id.Raw24.Set(t)
 	case 26:
 		var t [25]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw25.Set(t)
+		id.Raw25.Set(t)
 	case 27:
 		var t [26]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw26.Set(t)
+		id.Raw26.Set(t)
 	case 28:
 		var t [27]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw27.Set(t)
+		id.Raw27.Set(t)
 	case 29:
 		var t [28]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw28.Set(t)
+		id.Raw28.Set(t)
 	case 30:
 		var t [29]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw29.Set(t)
+		id.Raw29.Set(t)
 	case 31:
 		var t [30]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw30.Set(t)
+		id.Raw30.Set(t)
 	case 32:
 		var t [31]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw31.Set(t)
+		id.Raw31.Set(t)
 	case 33:
 		var t [32]byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Raw32.Set(t)
+		id.Raw32.Set(t)
 	case 34:
 		var t prim.H256
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.BlakeTwo256.Set(t)
+		id.BlakeTwo256.Set(t)
 	case 35:
 		var t prim.H256
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Sha256.Set(t)
+		id.Sha256.Set(t)
 	case 36:
 		var t prim.H256
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Keccak256.Set(t)
+		id.Keccak256.Set(t)
 	case 37:
 		var t prim.H256
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.ShaThree256.Set(t)
+		id.ShaThree256.Set(t)
 	default:
 		return errors.New("Unknown IdentityData Variant Index while Decoding")
 	}
@@ -1314,44 +1314,44 @@ type DispatchResult struct {
 	Err          prim.Option[DispatchError]
 }
 
-func (this DispatchResult) ToHuman() string {
-	return this.ToString()
+func (dr DispatchResult) ToHuman() string {
+	return dr.ToString()
 }
 
-func (this DispatchResult) ToString() string {
-	switch this.VariantIndex {
+func (dr DispatchResult) ToString() string {
+	switch dr.VariantIndex {
 	case 0:
 		return "Ok"
 	case 1:
-		return fmt.Sprintf(`Err: %v`, this.Err.Unwrap().ToHuman())
+		return fmt.Sprintf(`Err: %v`, dr.Err.Unwrap().ToHuman())
 	default:
 		panic("Unknown DispatchResult Variant Index")
 	}
 }
 
-func (this *DispatchResult) EncodeTo(dest *string) {
-	prim.Encoder.EncodeTo(this.VariantIndex, dest)
+func (dr *DispatchResult) EncodeTo(dest *string) {
+	prim.Encoder.EncodeTo(dr.VariantIndex, dest)
 
-	if this.Err.IsSome() {
-		prim.Encoder.EncodeTo(this.Err.Unwrap(), dest)
+	if dr.Err.IsSome() {
+		prim.Encoder.EncodeTo(dr.Err.Unwrap(), dest)
 	}
 }
 
-func (this *DispatchResult) Decode(decoder *prim.Decoder) error {
-	*this = DispatchResult{}
+func (dr *DispatchResult) Decode(decoder *prim.Decoder) error {
+	*dr = DispatchResult{}
 
-	if err := decoder.Decode(&this.VariantIndex); err != nil {
+	if err := decoder.Decode(&dr.VariantIndex); err != nil {
 		return err
 	}
 
-	switch this.VariantIndex {
+	switch dr.VariantIndex {
 	case 0:
 	case 1:
 		var t DispatchError
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Err.Set(t)
+		dr.Err.Set(t)
 	default:
 		return errors.New("Unknown DispatchResult Variant Index while Decoding")
 	}
@@ -1364,14 +1364,14 @@ type PoolBondExtra struct {
 	FreeBalance  prim.Option[Balance]
 }
 
-func (this PoolBondExtra) ToHuman() string {
-	return this.ToString()
+func (pbe PoolBondExtra) ToHuman() string {
+	return pbe.ToString()
 }
 
-func (this PoolBondExtra) ToString() string {
-	switch this.VariantIndex {
+func (pbe PoolBondExtra) ToString() string {
+	switch pbe.VariantIndex {
 	case 0:
-		return fmt.Sprintf("Free Balance: %v", this.FreeBalance.Unwrap().ToHuman())
+		return fmt.Sprintf("Free Balance: %v", pbe.FreeBalance.Unwrap().ToHuman())
 	case 1:
 		return "Rewards"
 	default:
@@ -1379,28 +1379,28 @@ func (this PoolBondExtra) ToString() string {
 	}
 }
 
-func (this *PoolBondExtra) EncodeTo(dest *string) {
-	prim.Encoder.EncodeTo(this.VariantIndex, dest)
+func (pbe *PoolBondExtra) EncodeTo(dest *string) {
+	prim.Encoder.EncodeTo(pbe.VariantIndex, dest)
 
-	if this.FreeBalance.IsSome() {
-		prim.Encoder.EncodeTo(this.FreeBalance.Unwrap(), dest)
+	if pbe.FreeBalance.IsSome() {
+		prim.Encoder.EncodeTo(pbe.FreeBalance.Unwrap(), dest)
 	}
 }
 
-func (this *PoolBondExtra) Decode(decoder *prim.Decoder) error {
-	*this = PoolBondExtra{}
+func (pbe *PoolBondExtra) Decode(decoder *prim.Decoder) error {
+	*pbe = PoolBondExtra{}
 
-	if err := decoder.Decode(&this.VariantIndex); err != nil {
+	if err := decoder.Decode(&pbe.VariantIndex); err != nil {
 		return err
 	}
 
-	switch this.VariantIndex {
+	switch pbe.VariantIndex {
 	case 0:
 		var t Balance
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.FreeBalance.Set(t)
+		pbe.FreeBalance.Set(t)
 	case 1:
 	default:
 		return errors.New("Unknown PoolBondExtra Variant Index while Decoding")
@@ -1414,16 +1414,16 @@ type PoolRoleConfig struct {
 	Set          prim.Option[prim.AccountId]
 }
 
-func (this PoolRoleConfig) ToHuman() string {
-	return this.ToString()
+func (prc PoolRoleConfig) ToHuman() string {
+	return prc.ToString()
 }
 
-func (this PoolRoleConfig) ToString() string {
-	switch this.VariantIndex {
+func (prc PoolRoleConfig) ToString() string {
+	switch prc.VariantIndex {
 	case 0:
 		return "Noop"
 	case 1:
-		return fmt.Sprintf("Set: %v", this.Set.Unwrap().ToHuman())
+		return fmt.Sprintf("Set: %v", prc.Set.Unwrap().ToHuman())
 	case 2:
 		return "Remove"
 	default:
@@ -1431,29 +1431,29 @@ func (this PoolRoleConfig) ToString() string {
 	}
 }
 
-func (this *PoolRoleConfig) EncodeTo(dest *string) {
-	prim.Encoder.EncodeTo(this.VariantIndex, dest)
+func (prc *PoolRoleConfig) EncodeTo(dest *string) {
+	prim.Encoder.EncodeTo(prc.VariantIndex, dest)
 
-	if this.Set.IsSome() {
-		prim.Encoder.EncodeTo(this.Set.Unwrap(), dest)
+	if prc.Set.IsSome() {
+		prim.Encoder.EncodeTo(prc.Set.Unwrap(), dest)
 	}
 }
 
-func (this *PoolRoleConfig) Decode(decoder *prim.Decoder) error {
-	*this = PoolRoleConfig{}
+func (prc *PoolRoleConfig) Decode(decoder *prim.Decoder) error {
+	*prc = PoolRoleConfig{}
 
-	if err := decoder.Decode(&this.VariantIndex); err != nil {
+	if err := decoder.Decode(&prc.VariantIndex); err != nil {
 		return err
 	}
 
-	switch this.VariantIndex {
+	switch prc.VariantIndex {
 	case 0:
 	case 1:
 		var t prim.AccountId
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.Set.Set(t)
+		prc.Set.Set(t)
 	case 2:
 	default:
 		return errors.New("Unknown PoolRoleConfig Variant Index while Decoding")
@@ -1480,54 +1480,54 @@ type MessageFungibleToken struct {
 	Amount  Balance `scale:"compact"`
 }
 
-func (this VectorMessage) ToHuman() string {
-	return this.ToString()
+func (vm VectorMessage) ToHuman() string {
+	return vm.ToString()
 }
 
-func (this VectorMessage) ToString() string {
-	switch this.VariantIndex {
+func (vm VectorMessage) ToString() string {
+	switch vm.VariantIndex {
 	case 0:
-		return fmt.Sprintf("ArbitraryMessage: %v", string(this.ArbitraryMessage.Unwrap()))
+		return fmt.Sprintf("ArbitraryMessage: %v", string(vm.ArbitraryMessage.Unwrap()))
 	case 1:
-		v := this.FungibleToken.Unwrap()
+		v := vm.FungibleToken.Unwrap()
 		return fmt.Sprintf("FungibleToken: Asset Id: %v,  Amount: %v", v.AssetId, v.Amount.String())
 	default:
 		panic("Unknown VectorMessage Variant Index")
 	}
 }
 
-func (this *VectorMessage) EncodeTo(dest *string) {
-	prim.Encoder.EncodeTo(this.VariantIndex, dest)
+func (vm *VectorMessage) EncodeTo(dest *string) {
+	prim.Encoder.EncodeTo(vm.VariantIndex, dest)
 
-	if this.ArbitraryMessage.IsSome() {
-		prim.Encoder.EncodeTo(this.ArbitraryMessage.Unwrap(), dest)
+	if vm.ArbitraryMessage.IsSome() {
+		prim.Encoder.EncodeTo(vm.ArbitraryMessage.Unwrap(), dest)
 	}
 
-	if this.FungibleToken.IsSome() {
-		prim.Encoder.EncodeTo(this.FungibleToken.Unwrap(), dest)
+	if vm.FungibleToken.IsSome() {
+		prim.Encoder.EncodeTo(vm.FungibleToken.Unwrap(), dest)
 	}
 }
 
-func (this *VectorMessage) Decode(decoder *prim.Decoder) error {
-	*this = VectorMessage{}
+func (vm *VectorMessage) Decode(decoder *prim.Decoder) error {
+	*vm = VectorMessage{}
 
-	if err := decoder.Decode(&this.VariantIndex); err != nil {
+	if err := decoder.Decode(&vm.VariantIndex); err != nil {
 		return err
 	}
 
-	switch this.VariantIndex {
+	switch vm.VariantIndex {
 	case 0:
 		var t []byte
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.ArbitraryMessage.Set(t)
+		vm.ArbitraryMessage.Set(t)
 	case 1:
 		var t MessageFungibleToken
 		if err := decoder.Decode(&t); err != nil {
 			return err
 		}
-		this.FungibleToken.Set(t)
+		vm.FungibleToken.Set(t)
 	default:
 		return errors.New("Unknown VectorMessage Variant Index while Decoding")
 	}
@@ -1582,12 +1582,12 @@ type ProxyType struct {
 	VariantIndex uint8
 }
 
-func (this ProxyType) ToHuman() string {
-	return this.ToString()
+func (pt ProxyType) ToHuman() string {
+	return pt.ToString()
 }
 
-func (this ProxyType) ToString() string {
-	switch this.VariantIndex {
+func (pt ProxyType) ToString() string {
+	switch pt.VariantIndex {
 	case 0:
 		return "Any"
 	case 1:
@@ -1605,18 +1605,18 @@ func (this ProxyType) ToString() string {
 	}
 }
 
-func (this *ProxyType) EncodeTo(dest *string) {
-	prim.Encoder.EncodeTo(this.VariantIndex, dest)
+func (pt *ProxyType) EncodeTo(dest *string) {
+	prim.Encoder.EncodeTo(pt.VariantIndex, dest)
 }
 
-func (this *ProxyType) Decode(decoder *prim.Decoder) error {
-	*this = ProxyType{}
+func (pt *ProxyType) Decode(decoder *prim.Decoder) error {
+	*pt = ProxyType{}
 
-	if err := decoder.Decode(&this.VariantIndex); err != nil {
+	if err := decoder.Decode(&pt.VariantIndex); err != nil {
 		return err
 	}
 
-	switch this.VariantIndex {
+	switch pt.VariantIndex {
 	case 0:
 	case 1:
 	case 2:

--- a/primitives/address.go
+++ b/primitives/address.go
@@ -24,69 +24,69 @@ func NewMultiAddressId(value AccountId) MultiAddress {
 	return address
 }
 
-func (this MultiAddress) ToAccountId() Option[AccountId] {
-	if this.Id.IsSome() {
-		return Some(this.Id.Unwrap())
+func (m MultiAddress) ToAccountId() Option[AccountId] {
+	if m.Id.IsSome() {
+		return Some(m.Id.Unwrap())
 	}
 	return None[AccountId]()
 }
 
-func (this *MultiAddress) EncodeTo(dest *string) {
-	Encoder.EncodeTo(this.VariantIndex, dest)
+func (m *MultiAddress) EncodeTo(dest *string) {
+	Encoder.EncodeTo(m.VariantIndex, dest)
 
-	if this.Id.IsSome() {
-		Encoder.EncodeTo(this.Id.Unwrap(), dest)
-	} else if this.Index.IsSome() {
-		Encoder.EncodeTo(this.Index.Unwrap(), dest)
-	} else if this.Raw.IsSome() {
-		Encoder.EncodeTo(this.Raw.Unwrap(), dest)
-	} else if this.Address32.IsSome() {
-		Encoder.EncodeTo(this.Address32.Unwrap(), dest)
-	} else if this.Address20.IsSome() {
-		Encoder.EncodeTo(this.Address20.Unwrap(), dest)
+	if m.Id.IsSome() {
+		Encoder.EncodeTo(m.Id.Unwrap(), dest)
+	} else if m.Index.IsSome() {
+		Encoder.EncodeTo(m.Index.Unwrap(), dest)
+	} else if m.Raw.IsSome() {
+		Encoder.EncodeTo(m.Raw.Unwrap(), dest)
+	} else if m.Address32.IsSome() {
+		Encoder.EncodeTo(m.Address32.Unwrap(), dest)
+	} else if m.Address20.IsSome() {
+		Encoder.EncodeTo(m.Address20.Unwrap(), dest)
 	} else {
 		panic("Something Went Wrong with MultiAddress EncodeTo")
 	}
 }
 
-func (this *MultiAddress) Decode(decoder *Decoder) error {
-	if err := decoder.Decode(&this.VariantIndex); err != nil {
+func (m *MultiAddress) Decode(decoder *Decoder) error {
+	if err := decoder.Decode(&m.VariantIndex); err != nil {
 		return err
 	}
 
-	switch this.VariantIndex {
+	switch m.VariantIndex {
 	case 0:
 		value := AccountId{}
 		if err := decoder.Decode(&value); err != nil {
 			return err
 		}
-		this.Id = Some(value)
+		m.Id = Some(value)
 	case 1:
 		value := uint32(0)
 		if err := decoder.Decode(&value); err != nil {
 			return err
 		}
-		this.Index = Some(value)
+		m.Index = Some(value)
 	case 2:
 		value := []byte{}
 		if err := decoder.Decode(&value); err != nil {
 			return err
 		}
-		this.Raw = Some(value)
+		m.Raw = Some(value)
 	case 3:
 		value := [32]byte{}
 		if err := decoder.Decode(&value); err != nil {
 			return err
 		}
-		this.Address32 = Some(value)
+		m.Address32 = Some(value)
 	case 4:
 		value := [20]byte{}
 		if err := decoder.Decode(&value); err != nil {
 			return err
 		}
-		this.Address20 = Some(value)
+		m.Address20 = Some(value)
 	default:
-		return errors.New(fmt.Sprintf(`MultiAddress Decode failure. Unknown Variant index: %v`, this.VariantIndex))
+		return errors.New(fmt.Sprintf(`MultiAddress Decode failure. Unknown Variant index: %v`, m.VariantIndex))
 	}
 
 	return nil
@@ -96,24 +96,24 @@ type AccountId struct {
 	Value H256
 }
 
-func (this AccountId) ToSS58() string {
-	return subkey.SS58Encode(this.Value.Value[:], 42)
+func (a AccountId) ToSS58() string {
+	return subkey.SS58Encode(a.Value.Value[:], 42)
 }
 
-func (this AccountId) ToAddress() string {
-	return this.ToSS58()
+func (a AccountId) ToAddress() string {
+	return a.ToSS58()
 }
 
-func (this AccountId) ToHuman() string {
-	return this.ToSS58()
+func (a AccountId) ToHuman() string {
+	return a.ToSS58()
 }
 
-func (this AccountId) ToString() string {
-	return this.Value.ToHex()
+func (a AccountId) ToString() string {
+	return a.Value.ToHex()
 }
 
-func (this AccountId) ToMultiAddress() MultiAddress {
-	return NewMultiAddressId(this)
+func (a AccountId) ToMultiAddress() MultiAddress {
+	return NewMultiAddressId(a)
 }
 
 func NewAccountIdFromKeyPair(keyPair subkey.KeyPair) AccountId {

--- a/primitives/already_encoded.go
+++ b/primitives/already_encoded.go
@@ -4,18 +4,18 @@ type AlreadyEncoded struct {
 	Value string
 }
 
-func (this *AlreadyEncoded) EncodeTo(dest *string) {
-	*dest += this.Value
+func (a *AlreadyEncoded) EncodeTo(dest *string) {
+	*dest += a.Value
 }
 
-func (this *AlreadyEncoded) ToHex() string {
-	return this.Value
+func (a *AlreadyEncoded) ToHex() string {
+	return a.Value
 }
 
-func (this *AlreadyEncoded) ToHexWith0x() string {
-	return "0x" + this.Value
+func (a *AlreadyEncoded) ToHexWith0x() string {
+	return "0x" + a.Value
 }
 
-func (this *AlreadyEncoded) ToBytes() []byte {
-	return Hex.FromHex(this.Value)
+func (a *AlreadyEncoded) ToBytes() []byte {
+	return Hex.FromHex(a.Value)
 }

--- a/primitives/extrinsics_encoded.go
+++ b/primitives/extrinsics_encoded.go
@@ -10,24 +10,24 @@ type EncodedExtrinsic struct {
 	Value string
 }
 
-func (this *EncodedExtrinsic) Encode() string {
-	return this.Value
+func (e *EncodedExtrinsic) Encode() string {
+	return e.Value
 }
 
-func (this *EncodedExtrinsic) ToHex() string {
-	return this.Value
+func (e *EncodedExtrinsic) ToHex() string {
+	return e.Value
 }
 
-func (this *EncodedExtrinsic) ToHexWith0x() string {
-	return "0x" + this.ToHex()
+func (e *EncodedExtrinsic) ToHexWith0x() string {
+	return "0x" + e.ToHex()
 }
 
-func (this *EncodedExtrinsic) HexToBytes() []byte {
-	return utiles.HexToBytes(this.Value)
+func (e *EncodedExtrinsic) HexToBytes() []byte {
+	return utiles.HexToBytes(e.Value)
 }
 
-func (this *EncodedExtrinsic) Decode(txIndex uint32) (DecodedExtrinsic, error) {
-	return NewDecodedExtrinsic(*this, txIndex)
+func (e *EncodedExtrinsic) Decode(txIndex uint32) (DecodedExtrinsic, error) {
+	return NewDecodedExtrinsic(*e, txIndex)
 }
 
 func NewEncodedExtrinsic(payloadExtra *AlreadyEncoded, payloadCall *AlreadyEncoded, address MultiAddress, signature MultiSignature) EncodedExtrinsic {

--- a/primitives/hash_h256.go
+++ b/primitives/hash_h256.go
@@ -11,28 +11,28 @@ type H256 struct {
 	Value [32]byte
 }
 
-func (this H256) ToHex() string {
-	return SUtiles.BytesToHex(this.Value[:])
+func (h H256) ToHex() string {
+	return SUtiles.BytesToHex(h.Value[:])
 }
 
-func (this H256) ToHexWith0x() string {
-	return "0x" + this.ToHex()
+func (h H256) ToHexWith0x() string {
+	return "0x" + h.ToHex()
 }
 
-func (this H256) ToHuman() string {
-	return this.ToHexWith0x()
+func (h H256) ToHuman() string {
+	return h.ToHexWith0x()
 }
 
-func (this H256) ToString() string {
-	return this.ToHexWith0x()
+func (h H256) ToString() string {
+	return h.ToHexWith0x()
 }
 
-func (this H256) String() string {
-	return this.ToHexWith0x()
+func (h H256) String() string {
+	return h.ToHexWith0x()
 }
 
-func (this H256) ToRpcParam() string {
-	return "\"" + this.ToHexWith0x() + "\""
+func (h H256) ToRpcParam() string {
+	return "\"" + h.ToHexWith0x() + "\""
 }
 
 func NewH256FromHexString(hexString string) (H256, error) {

--- a/primitives/hash_h512.go
+++ b/primitives/hash_h512.go
@@ -11,16 +11,16 @@ type H512 struct {
 	Value [64]byte
 }
 
-func (this *H512) ToHex() string {
-	return SUtiles.BytesToHex(this.Value[:])
+func (h *H512) ToHex() string {
+	return SUtiles.BytesToHex(h.Value[:])
 }
 
-func (this *H512) ToHexWith0x() string {
-	return "0x" + this.ToHex()
+func (h *H512) ToHexWith0x() string {
+	return "0x" + h.ToHex()
 }
 
-func (this *H512) ToRpcParam() string {
-	return "\"" + this.ToHexWith0x() + "\""
+func (h *H512) ToRpcParam() string {
+	return "\"" + h.ToHexWith0x() + "\""
 }
 
 func NewH512FromHexString(hexString string) (H512, error) {

--- a/primitives/hash_h520.go
+++ b/primitives/hash_h520.go
@@ -11,16 +11,16 @@ type H520 struct {
 	Value [65]byte
 }
 
-func (this *H520) ToHex() string {
-	return SUtiles.BytesToHex(this.Value[:])
+func (h *H520) ToHex() string {
+	return SUtiles.BytesToHex(h.Value[:])
 }
 
-func (this *H520) ToHexWith0x() string {
-	return "0x" + this.ToHex()
+func (h *H520) ToHexWith0x() string {
+	return "0x" + h.ToHex()
 }
 
-func (this *H520) ToRpcParam() string {
-	return "\"" + this.ToHexWith0x() + "\""
+func (h *H520) ToRpcParam() string {
+	return "\"" + h.ToHexWith0x() + "\""
 }
 
 func NewH520FromHexString(hexString string) (H520, error) {

--- a/primitives/scale_decoder.go
+++ b/primitives/scale_decoder.go
@@ -17,7 +17,7 @@ type Decoder struct {
 }
 
 // Fixed arrays
-func (this *Decoder) array(value reflect.Value) error {
+func (de *Decoder) array(value reflect.Value) error {
 	elemType := value.Type().Elem()
 	arrayType := reflect.ArrayOf(value.Len(), elemType)
 	arrayPointer := reflect.New(arrayType)
@@ -26,7 +26,7 @@ func (this *Decoder) array(value reflect.Value) error {
 	for i := 0; i < int(value.Len()); i++ {
 		elem := reflect.New(elemType).Elem()
 
-		if err := this.Decode(elem.Addr().Interface()); err != nil {
+		if err := de.Decode(elem.Addr().Interface()); err != nil {
 			return err
 		}
 
@@ -38,9 +38,9 @@ func (this *Decoder) array(value reflect.Value) error {
 }
 
 // Dynamic arrays
-func (this *Decoder) slice(value reflect.Value) error {
+func (de *Decoder) slice(value reflect.Value) error {
 	len := CompactU32{}
-	if err := this.Decode(&len); err != nil {
+	if err := de.Decode(&len); err != nil {
 		return err
 	}
 
@@ -49,7 +49,7 @@ func (this *Decoder) slice(value reflect.Value) error {
 
 	for i := 0; i < int(len.Value); i++ {
 		elem := reflect.New(elemType).Elem()
-		if err := this.Decode(elem.Addr().Interface()); err != nil {
+		if err := de.Decode(elem.Addr().Interface()); err != nil {
 			return err
 		}
 
@@ -60,11 +60,11 @@ func (this *Decoder) slice(value reflect.Value) error {
 	return nil
 }
 
-func (this *Decoder) callMethod(value reflect.Value) error {
+func (de *Decoder) callMethod(value reflect.Value) error {
 	methodName := "Decode"
 	method := value.MethodByName(methodName)
 
-	args := []reflect.Value{reflect.ValueOf(this)}
+	args := []reflect.Value{reflect.ValueOf(de)}
 	results := method.Call(args)
 
 	if len(results) == 0 {
@@ -79,7 +79,7 @@ func (this *Decoder) callMethod(value reflect.Value) error {
 	return res.(error)
 }
 
-func (this *Decoder) structureFields(value reflect.Value, isCompact bool) error {
+func (de *Decoder) structureFields(value reflect.Value, isCompact bool) error {
 	valueType := value.Type()
 
 	for i := 0; i < valueType.NumField(); i++ {
@@ -97,7 +97,7 @@ func (this *Decoder) structureFields(value reflect.Value, isCompact bool) error 
 
 		fieldValue := value.Field(i)
 
-		if err := this.decodeInner(fieldValue.Addr(), filedIsCompact); err != nil {
+		if err := de.decodeInner(fieldValue.Addr(), filedIsCompact); err != nil {
 			return err
 		}
 	}
@@ -105,80 +105,80 @@ func (this *Decoder) structureFields(value reflect.Value, isCompact bool) error 
 	return nil
 }
 
-func (this *Decoder) primitives(value reflect.Value, isCompact bool) (error, bool) {
+func (de *Decoder) primitives(value reflect.Value, isCompact bool) (error, bool) {
 	kind := value.Kind().String()
 	name := value.Type().Name()
 
 	if !isCompact {
 		if kind == "bool" {
-			if !this.HasAtLeastRemainingBytes(1) {
+			if !de.HasAtLeastRemainingBytes(1) {
 				return errors.New(`Decoder failed. Out of Bytes`), true
 			}
 
 			decoder := SType.Bool{}
-			decoder.Init(this.ScaleBytes, nil)
+			decoder.Init(de.ScaleBytes, nil)
 			decoder.Process()
-			this.ScaleBytes.Offset = decoder.Data.Offset
+			de.ScaleBytes.Offset = decoder.Data.Offset
 
 			res := decoder.Value.(bool)
 			value.Set(reflect.ValueOf(res))
 			return nil, true
 		}
 		if kind == "uint8" {
-			if !this.HasAtLeastRemainingBytes(1) {
+			if !de.HasAtLeastRemainingBytes(1) {
 				return errors.New(`Decoder failed. Out of Bytes`), true
 			}
 
 			decoder := SType.U8{}
-			decoder.Init(this.ScaleBytes, nil)
+			decoder.Init(de.ScaleBytes, nil)
 			decoder.Process()
 
-			this.ScaleBytes.Offset = decoder.Data.Offset
+			de.ScaleBytes.Offset = decoder.Data.Offset
 
 			res := uint8(decoder.Value.(int))
 			value.Set(reflect.ValueOf(res))
 			return nil, true
 		}
 		if kind == "uint16" {
-			if !this.HasAtLeastRemainingBytes(2) {
+			if !de.HasAtLeastRemainingBytes(2) {
 				return errors.New(`Decoder failed. Out of Bytes`), true
 			}
 
 			decoder := SType.U16{}
-			decoder.Init(this.ScaleBytes, nil)
+			decoder.Init(de.ScaleBytes, nil)
 			decoder.Process()
 
-			this.ScaleBytes.Offset = decoder.Data.Offset
+			de.ScaleBytes.Offset = decoder.Data.Offset
 
 			res := decoder.Value.(uint16)
 			value.Set(reflect.ValueOf(res))
 			return nil, true
 		}
 		if kind == "uint32" {
-			if !this.HasAtLeastRemainingBytes(4) {
+			if !de.HasAtLeastRemainingBytes(4) {
 				return errors.New(`Decoder failed. Out of Bytes`), true
 			}
 
 			decoder := SType.U32{}
-			decoder.Init(this.ScaleBytes, nil)
+			decoder.Init(de.ScaleBytes, nil)
 			decoder.Process()
 
-			this.ScaleBytes.Offset = decoder.Data.Offset
+			de.ScaleBytes.Offset = decoder.Data.Offset
 
 			res := decoder.Value.(uint32)
 			value.Set(reflect.ValueOf(res))
 			return nil, true
 		}
 		if kind == "uint64" {
-			if !this.HasAtLeastRemainingBytes(8) {
+			if !de.HasAtLeastRemainingBytes(8) {
 				return errors.New(`Decoder failed. Out of Bytes`), true
 			}
 
 			decoder := SType.U64{}
-			decoder.Init(this.ScaleBytes, nil)
+			decoder.Init(de.ScaleBytes, nil)
 			decoder.Process()
 
-			this.ScaleBytes.Offset = decoder.Data.Offset
+			de.ScaleBytes.Offset = decoder.Data.Offset
 
 			res := decoder.Value.(uint64)
 			value.Set(reflect.ValueOf(res))
@@ -186,25 +186,25 @@ func (this *Decoder) primitives(value reflect.Value, isCompact bool) (error, boo
 		}
 		if kind == "string" {
 			decoder := SType.String{}
-			decoder.Init(this.ScaleBytes, nil)
+			decoder.Init(de.ScaleBytes, nil)
 			decoder.Process()
 
-			this.ScaleBytes.Offset = decoder.Data.Offset
+			de.ScaleBytes.Offset = decoder.Data.Offset
 
 			res := decoder.Value.(string)
 			value.Set(reflect.ValueOf(res))
 			return nil, true
 		}
 		if name == "Uint128" {
-			if !this.HasAtLeastRemainingBytes(16) {
+			if !de.HasAtLeastRemainingBytes(16) {
 				return errors.New(`Decoder failed. Out of Bytes`), true
 			}
 
 			decoder := SType.U128{}
-			decoder.Init(this.ScaleBytes, nil)
+			decoder.Init(de.ScaleBytes, nil)
 			decoder.Process()
 
-			this.ScaleBytes.Offset = decoder.Data.Offset
+			de.ScaleBytes.Offset = decoder.Data.Offset
 
 			valueDecoded, _ := new(big.Int).SetString(decoder.Value.(string), 10)
 			res := uint128.FromBig(valueDecoded)
@@ -217,20 +217,20 @@ func (this *Decoder) primitives(value reflect.Value, isCompact bool) (error, boo
 			decoder := SType.Compact{}
 			options := SType.ScaleDecoderOption{}
 			options.SubType = "u16"
-			decoder.Init(this.ScaleBytes, &options)
+			decoder.Init(de.ScaleBytes, &options)
 			decoder.Process()
 
-			this.ScaleBytes.Offset = decoder.Data.Offset
+			de.ScaleBytes.Offset = decoder.Data.Offset
 			res := decoder.Value.(uint16)
 			value.Set(reflect.ValueOf(res))
 			return nil, true
 		}
 		if kind == "uint32" {
 			decoder := SType.CompactU32{}
-			decoder.Init(this.ScaleBytes, nil)
+			decoder.Init(de.ScaleBytes, nil)
 			decoder.Process()
 
-			this.ScaleBytes.Offset = decoder.Data.Offset
+			de.ScaleBytes.Offset = decoder.Data.Offset
 			res := uint32(decoder.Value.(int))
 			value.Set(reflect.ValueOf(res))
 			return nil, true
@@ -240,10 +240,10 @@ func (this *Decoder) primitives(value reflect.Value, isCompact bool) (error, boo
 			decoder := SType.Compact{}
 			options := SType.ScaleDecoderOption{}
 			options.SubType = "u64"
-			decoder.Init(this.ScaleBytes, &options)
+			decoder.Init(de.ScaleBytes, &options)
 			decoder.Process()
 
-			this.ScaleBytes.Offset = decoder.Data.Offset
+			de.ScaleBytes.Offset = decoder.Data.Offset
 			res := decoder.Value.(uint64)
 			value.Set(reflect.ValueOf(res))
 			return nil, true
@@ -252,10 +252,10 @@ func (this *Decoder) primitives(value reflect.Value, isCompact bool) (error, boo
 			decoder := SType.Compact{}
 			options := SType.ScaleDecoderOption{}
 			options.SubType = "u128"
-			decoder.Init(this.ScaleBytes, &options)
+			decoder.Init(de.ScaleBytes, &options)
 			decoder.Process()
 
-			this.ScaleBytes.Offset = decoder.Data.Offset
+			de.ScaleBytes.Offset = decoder.Data.Offset
 
 			valueBytes := decoder.Value.(decimal.Decimal)
 			valueDecoded, _ := new(big.Int).SetString(valueBytes.String(), 10)
@@ -269,10 +269,10 @@ func (this *Decoder) primitives(value reflect.Value, isCompact bool) (error, boo
 	return nil, false
 }
 
-func (this *Decoder) Decode(value interface{}) error {
+func (de *Decoder) Decode(value interface{}) error {
 	valueOf := reflect.ValueOf(value)
 
-	if err := this.decodeInner(valueOf, false); err != nil {
+	if err := de.decodeInner(valueOf, false); err != nil {
 		// If failed reset the value to zero
 		if valueOf.Kind() == reflect.Ptr {
 			elem := valueOf.Elem()
@@ -285,7 +285,7 @@ func (this *Decoder) Decode(value interface{}) error {
 	return nil
 }
 
-func (this *Decoder) decodeInner(value reflect.Value, isCompact bool) error {
+func (de *Decoder) decodeInner(value reflect.Value, isCompact bool) error {
 	if value.Kind() != reflect.Ptr {
 		return errors.New("Decoder failed. The passed value is not of pointer type")
 	}
@@ -294,22 +294,22 @@ func (this *Decoder) decodeInner(value reflect.Value, isCompact bool) error {
 		return errors.New("Decoder failed. The passed value cannot be changed. CanSet is set to false")
 	}
 
-	if this.hasCallMethod(value) {
-		return this.callMethod(value)
+	if de.hasCallMethod(value) {
+		return de.callMethod(value)
 	}
 
 	pointee := value.Elem()
-	if res, ok := this.primitives(pointee, isCompact); ok {
+	if res, ok := de.primitives(pointee, isCompact); ok {
 		return res
 	}
 
 	switch pointee.Kind() {
 	case reflect.Slice:
-		return this.slice(pointee)
+		return de.slice(pointee)
 	case reflect.Array:
-		return this.array(pointee)
+		return de.array(pointee)
 	case reflect.Struct:
-		return this.structureFields(pointee, isCompact)
+		return de.structureFields(pointee, isCompact)
 	default:
 		elemKind := pointee.Kind()
 		elemName := pointee.Type().Name()
@@ -317,7 +317,7 @@ func (this *Decoder) decodeInner(value reflect.Value, isCompact bool) error {
 	}
 }
 
-func (this *Decoder) hasCallMethod(value reflect.Value) bool {
+func (de *Decoder) hasCallMethod(value reflect.Value) bool {
 	methodName := "Decode"
 	method := value.MethodByName(methodName)
 
@@ -330,23 +330,23 @@ func NewDecoder(data []byte, offset int) Decoder {
 	}
 }
 
-func (this *Decoder) Offset() int {
-	return this.ScaleBytes.Offset
+func (de *Decoder) Offset() int {
+	return de.ScaleBytes.Offset
 }
 
-func (this *Decoder) RemainingLength() int {
-	return this.ScaleBytes.GetRemainingLength()
+func (de *Decoder) RemainingLength() int {
+	return de.ScaleBytes.GetRemainingLength()
 }
 
-func (this *Decoder) HasAtLeastRemainingBytes(atLeast int) bool {
-	return this.ScaleBytes.GetRemainingLength() >= atLeast
+func (de *Decoder) HasAtLeastRemainingBytes(atLeast int) bool {
+	return de.ScaleBytes.GetRemainingLength() >= atLeast
 }
 
-func (this *Decoder) NextBytes(length int) []byte {
-	return this.ScaleBytes.GetNextBytes(length)
+func (de *Decoder) NextBytes(length int) []byte {
+	return de.ScaleBytes.GetNextBytes(length)
 }
 
 // This is just a different name for GetNextBytes
-func (this *Decoder) StaticArray(byteCount int) []byte {
-	return this.ScaleBytes.GetNextBytes(byteCount)
+func (de *Decoder) StaticArray(byteCount int) []byte {
+	return de.ScaleBytes.GetNextBytes(byteCount)
 }

--- a/primitives/scale_encoder_test.go
+++ b/primitives/scale_encoder_test.go
@@ -291,12 +291,12 @@ type DummyStruct2 struct {
 	value uint32
 }
 
-func (this DummyStruct2) EncodeTo(dest *string) {
+func (d DummyStruct2) EncodeTo(dest *string) {
 	*dest = "Success"
 }
 
-func (this *DummyStruct2) Decode(decoder *Decoder) error {
-	this.value = uint32(0xbeef)
+func (d *DummyStruct2) Decode(decoder *Decoder) error {
+	d.value = uint32(0xbeef)
 	return nil
 }
 
@@ -304,7 +304,7 @@ type DummyStruct3 struct {
 	value uint32
 }
 
-func (this *DummyStruct3) EncodeTo(dest *string) {
+func (d *DummyStruct3) EncodeTo(dest *string) {
 	*dest = "Success"
 }
 

--- a/primitives/scale_types.go
+++ b/primitives/scale_types.go
@@ -11,99 +11,99 @@ type Option[T any] struct {
 	isSet bool
 }
 
-func (this *Option[T]) EncodeTo(dest *string) {
-	if !this.isSet {
+func (o *Option[T]) EncodeTo(dest *string) {
+	if !o.isSet {
 		Encoder.EncodeTo(uint8(0), dest)
 		return
 	}
 	Encoder.EncodeTo(uint8(1), dest)
-	Encoder.EncodeTo(this.value, dest)
+	Encoder.EncodeTo(o.value, dest)
 }
 
-func (this *Option[T]) Decode(decoder *Decoder) error {
+func (o *Option[T]) Decode(decoder *Decoder) error {
 	hasValue := uint8(0)
 	if err := decoder.Decode(&hasValue); err != nil {
 		return err
 	}
 	if hasValue == 1 {
-		this.isSet = true
-		if err := decoder.Decode(&this.value); err != nil {
+		o.isSet = true
+		if err := decoder.Decode(&o.value); err != nil {
 			return err
 		}
 	} else {
-		this.isSet = false
+		o.isSet = false
 	}
 
 	return nil
 }
 
-func (this *Option[T]) Set(value T) {
-	this.value = value
-	this.isSet = true
+func (o *Option[T]) Set(value T) {
+	o.value = value
+	o.isSet = true
 }
 
-func (this *Option[T]) Unset() {
+func (o *Option[T]) Unset() {
 	var t T
-	this.value = t
-	this.isSet = false
+	o.value = t
+	o.isSet = false
 }
 
-func (this Option[T]) IsSome() bool {
-	return this.isSet
+func (o Option[T]) IsSome() bool {
+	return o.isSet
 }
 
-func (this Option[T]) IsNone() bool {
-	return !this.isSet
+func (o Option[T]) IsNone() bool {
+	return !o.isSet
 }
 
-func (this Option[T]) String() string {
-	if this.isSet {
-		return fmt.Sprintf("Some(%v)", this.value)
+func (o Option[T]) String() string {
+	if o.isSet {
+		return fmt.Sprintf("Some(%v)", o.value)
 	} else {
 		return "None"
 	}
 }
 
-func (this Option[T]) ToString() string {
-	return this.String()
+func (o Option[T]) ToString() string {
+	return o.String()
 }
 
-func (this Option[T]) ToHuman() string {
-	return this.String()
+func (o Option[T]) ToHuman() string {
+	return o.String()
 }
 
 // This function does not panic when no value is set.
 //
 // If Set, returns set value.
 // If Not Set, returns default value.
-func (this Option[T]) Unwrap() T {
-	if this.isSet == false {
+func (o Option[T]) Unwrap() T {
+	if o.isSet == false {
 		var t T
 		return t
 	}
-	return this.value
+	return o.value
 }
 
 // This function will panic when no value is set.
 //
 // If Set, returns set value.
 // If Not Set, panics
-func (this Option[T]) UnsafeUnwrap() T {
-	if this.isSet == false {
+func (o Option[T]) UnsafeUnwrap() T {
+	if o.isSet == false {
 		panic("Option is not set.")
 	}
-	return this.value
+	return o.value
 }
 
 // This function does not panic when no value is set.
 //
 // If Set, returns set value.
 // If Not Set, returns value specified as parameter.
-func (this Option[T]) UnwrapOr(elseValue T) T {
-	if this.isSet == false {
+func (o Option[T]) UnwrapOr(elseValue T) T {
+	if o.isSet == false {
 		return elseValue
 	}
-	return this.value
+	return o.value
 }
 
 func Some[T any](value T) Option[T] {

--- a/primitives/signature.go
+++ b/primitives/signature.go
@@ -38,23 +38,23 @@ func NewMultiSignatureEcdsa(value H520) MultiSignature {
 	return signature
 }
 
-func (this *MultiSignature) EncodeTo(dest *string) {
-	if this.Ed25519.IsSome() {
+func (m *MultiSignature) EncodeTo(dest *string) {
+	if m.Ed25519.IsSome() {
 		Encoder.EncodeTo(uint8(0), dest)
-		Encoder.EncodeTo(this.Ed25519.Unwrap(), dest)
-	} else if this.Sr25519.IsSome() {
+		Encoder.EncodeTo(m.Ed25519.Unwrap(), dest)
+	} else if m.Sr25519.IsSome() {
 		Encoder.EncodeTo(uint8(1), dest)
-		Encoder.EncodeTo(this.Sr25519.Unwrap(), dest)
-	} else if this.Ecdsa.IsSome() {
+		Encoder.EncodeTo(m.Sr25519.Unwrap(), dest)
+	} else if m.Ecdsa.IsSome() {
 		Encoder.EncodeTo(uint8(2), dest)
-		Encoder.EncodeTo(this.Ecdsa.Unwrap(), dest)
+		Encoder.EncodeTo(m.Ecdsa.Unwrap(), dest)
 	} else {
 		panic("Something Went Wrong with MultiSignature EncodeTo")
 	}
 
 }
 
-func (this *MultiSignature) Decode(decoder *Decoder) error {
+func (m *MultiSignature) Decode(decoder *Decoder) error {
 	result := emptyMultiSignature()
 	variantIndex := uint8(0)
 	decoder.Decode(&variantIndex)
@@ -80,6 +80,6 @@ func (this *MultiSignature) Decode(decoder *Decoder) error {
 		return errors.New(fmt.Sprintf(`MultiSignature Decode failure. Unknown Variant index: %v`, variantIndex))
 	}
 
-	*this = result
+	*m = result
 	return nil
 }

--- a/sdk/block.go
+++ b/sdk/block.go
@@ -14,24 +14,24 @@ type Filter struct {
 	TxSigner prim.Option[prim.AccountId]
 }
 
-func (this Filter) WAppId(value uint32) Filter {
-	this.AppId = prim.Some(value)
-	return this
+func (f Filter) WAppId(value uint32) Filter {
+	f.AppId = prim.Some(value)
+	return f
 }
 
-func (this Filter) WTxHash(value prim.H256) Filter {
-	this.TxHash = prim.Some(value)
-	return this
+func (f Filter) WTxHash(value prim.H256) Filter {
+	f.TxHash = prim.Some(value)
+	return f
 }
 
-func (this Filter) WTxIndex(value uint32) Filter {
-	this.TxIndex = prim.Some(value)
-	return this
+func (f Filter) WTxIndex(value uint32) Filter {
+	f.TxIndex = prim.Some(value)
+	return f
 }
 
-func (this Filter) WTxSigner(value prim.AccountId) Filter {
-	this.TxSigner = prim.Some(value)
-	return this
+func (f Filter) WTxSigner(value prim.AccountId) Filter {
+	f.TxSigner = prim.Some(value)
+	return f
 }
 
 type Block struct {
@@ -77,10 +77,10 @@ func NewFinalizedBlock(client *Client) (Block, error) {
 	return NewBlock(client, hash)
 }
 
-func (this *Block) Transactions(filter Filter) []BlockTransaction {
-	extrinsics := this.Block.Extrinsics
+func (b *Block) Transactions(filter Filter) []BlockTransaction {
+	extrinsics := b.Block.Extrinsics
 	result := []BlockTransaction{}
-	for i := range this.Block.Extrinsics {
+	for i := range b.Block.Extrinsics {
 		ext := &extrinsics[i]
 
 		if filter.AppId.IsSome() {
@@ -111,15 +111,15 @@ func (this *Block) Transactions(filter Filter) []BlockTransaction {
 			}
 		}
 
-		txEvents := this.EventsForTransaction(extrinsics[i].TxIndex)
-		result = append(result, NewBlockTransaction(this.client, &extrinsics[i], txEvents))
+		txEvents := b.EventsForTransaction(extrinsics[i].TxIndex)
+		result = append(result, NewBlockTransaction(b.client, &extrinsics[i], txEvents))
 	}
 
 	return result
 }
 
-func (this *Block) DataSubmissions(filter Filter) []DataSubmission {
-	extrinsics := this.Block.Extrinsics
+func (b *Block) DataSubmissions(filter Filter) []DataSubmission {
+	extrinsics := b.Block.Extrinsics
 	result := []DataSubmission{}
 	for i := range extrinsics {
 		ext := &extrinsics[i]
@@ -160,22 +160,22 @@ func (this *Block) DataSubmissions(filter Filter) []DataSubmission {
 	return result
 }
 
-func (this *Block) EventsForTransaction(txIndex uint32) prim.Option[EventRecords] {
-	if this.events.IsNone() {
+func (b *Block) EventsForTransaction(txIndex uint32) prim.Option[EventRecords] {
+	if b.events.IsNone() {
 		return prim.None[EventRecords]()
 	}
 
-	if txIndex >= uint32(len(this.Block.Extrinsics)) {
+	if txIndex >= uint32(len(b.Block.Extrinsics)) {
 		return prim.None[EventRecords]()
 	}
 
-	allEvents := this.events.Unwrap()
+	allEvents := b.events.Unwrap()
 	txEvents := EventFilterByTxIndex(allEvents, txIndex)
 	return prim.Some(txEvents)
 }
 
-func (this *Block) Events() prim.Option[EventRecords] {
-	return this.events
+func (b *Block) Events() prim.Option[EventRecords] {
+	return b.events
 }
 
 func sameSignature(tx *prim.DecodedExtrinsic, accountId prim.AccountId) bool {

--- a/sdk/block_transaction.go
+++ b/sdk/block_transaction.go
@@ -30,44 +30,44 @@ func NewBlockTransaction(client *Client, extrinsic *prim.DecodedExtrinsic, event
 	}
 }
 
-func (this *BlockTransaction) PalletName() string {
-	return this.palletName
+func (b *BlockTransaction) PalletName() string {
+	return b.palletName
 }
 
-func (this *BlockTransaction) CallName() string {
-	return this.callName
+func (b *BlockTransaction) CallName() string {
+	return b.callName
 }
 
-func (this *BlockTransaction) PalletIndex() uint8 {
-	return this.Extrinsic.Call.PalletIndex
+func (b *BlockTransaction) PalletIndex() uint8 {
+	return b.Extrinsic.Call.PalletIndex
 }
 
-func (this *BlockTransaction) CallIndex() uint8 {
-	return this.Extrinsic.Call.CallIndex
+func (b *BlockTransaction) CallIndex() uint8 {
+	return b.Extrinsic.Call.CallIndex
 }
 
-func (this *BlockTransaction) TxHash() prim.H256 {
-	return this.Extrinsic.TxHash
+func (b *BlockTransaction) TxHash() prim.H256 {
+	return b.Extrinsic.TxHash
 }
 
-func (this *BlockTransaction) TxIndex() uint32 {
-	return this.Extrinsic.TxIndex
+func (b *BlockTransaction) TxIndex() uint32 {
+	return b.Extrinsic.TxIndex
 }
 
-func (this *BlockTransaction) Signed() prim.Option[prim.DecodedExtrinsicSigned] {
-	return this.Extrinsic.Signed
+func (b *BlockTransaction) Signed() prim.Option[prim.DecodedExtrinsicSigned] {
+	return b.Extrinsic.Signed
 }
 
-func (this *BlockTransaction) Fields() prim.AlreadyEncoded {
-	return this.Extrinsic.Call.Fields
+func (b *BlockTransaction) Fields() prim.AlreadyEncoded {
+	return b.Extrinsic.Call.Fields
 }
 
-func (this *BlockTransaction) Events() prim.Option[EventRecords] {
-	return this.events
+func (b *BlockTransaction) Events() prim.Option[EventRecords] {
+	return b.events
 }
 
-func (this *BlockTransaction) MultiAddress() prim.Option[prim.MultiAddress] {
-	signed := this.Signed()
+func (b *BlockTransaction) MultiAddress() prim.Option[prim.MultiAddress] {
+	signed := b.Signed()
 	if signed.IsNone() {
 		return prim.None[prim.MultiAddress]()
 	}
@@ -77,8 +77,8 @@ func (this *BlockTransaction) MultiAddress() prim.Option[prim.MultiAddress] {
 	return prim.Some(address)
 }
 
-func (this *BlockTransaction) AccountId() prim.Option[prim.AccountId] {
-	multiMyb := this.MultiAddress()
+func (b *BlockTransaction) AccountId() prim.Option[prim.AccountId] {
+	multiMyb := b.MultiAddress()
 	if multiMyb.IsNone() {
 		return prim.None[prim.AccountId]()
 	}
@@ -92,8 +92,8 @@ func (this *BlockTransaction) AccountId() prim.Option[prim.AccountId] {
 	return prim.Some(multi.Id.Unwrap())
 }
 
-func (this *BlockTransaction) SS58Address() prim.Option[string] {
-	accountId := this.AccountId()
+func (b *BlockTransaction) SS58Address() prim.Option[string] {
+	accountId := b.AccountId()
 	if accountId.IsNone() {
 		return prim.None[string]()
 	}
@@ -101,8 +101,8 @@ func (this *BlockTransaction) SS58Address() prim.Option[string] {
 	return prim.Some(accountId.Unwrap().ToHuman())
 }
 
-func (this *BlockTransaction) AppId() prim.Option[uint32] {
-	signed := this.Signed()
+func (b *BlockTransaction) AppId() prim.Option[uint32] {
+	signed := b.Signed()
 	if signed.IsNone() {
 		return prim.None[uint32]()
 	}
@@ -110,8 +110,8 @@ func (this *BlockTransaction) AppId() prim.Option[uint32] {
 	return prim.Some(signed.Unwrap().AppId)
 }
 
-func (this *BlockTransaction) Tip() prim.Option[metadata.Balance] {
-	signed := this.Signed()
+func (b *BlockTransaction) Tip() prim.Option[metadata.Balance] {
+	signed := b.Signed()
 	if signed.IsNone() {
 		return prim.None[metadata.Balance]()
 	}
@@ -119,8 +119,8 @@ func (this *BlockTransaction) Tip() prim.Option[metadata.Balance] {
 	return prim.Some(metadata.Balance{Value: signed.Unwrap().Tip})
 }
 
-func (this *BlockTransaction) Mortality() prim.Option[prim.Era] {
-	signed := this.Signed()
+func (b *BlockTransaction) Mortality() prim.Option[prim.Era] {
+	signed := b.Signed()
 	if signed.IsNone() {
 		return prim.None[prim.Era]()
 	}
@@ -128,8 +128,8 @@ func (this *BlockTransaction) Mortality() prim.Option[prim.Era] {
 	return prim.Some(signed.Unwrap().Era)
 }
 
-func (this *BlockTransaction) Nonce() prim.Option[uint32] {
-	signed := this.Signed()
+func (b *BlockTransaction) Nonce() prim.Option[uint32] {
+	signed := b.Signed()
 	if signed.IsNone() {
 		return prim.None[uint32]()
 	}

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -35,47 +35,47 @@ func NewClient(endpoint string) *Client {
 	return client
 }
 
-func (this *Client) BlockNumber(blockHash prim.H256) (uint32, error) {
-	header, err := this.Rpc.Chain.GetHeader(prim.Some(blockHash))
+func (c *Client) BlockNumber(blockHash prim.H256) (uint32, error) {
+	header, err := c.Rpc.Chain.GetHeader(prim.Some(blockHash))
 	return header.Number, err
 }
 
-func (this *Client) BestBlockNumber() (uint32, error) {
-	header, err := this.Rpc.Chain.GetHeader(prim.None[prim.H256]())
+func (c *Client) BestBlockNumber() (uint32, error) {
+	header, err := c.Rpc.Chain.GetHeader(prim.None[prim.H256]())
 	return header.Number, err
 }
 
-func (this *Client) FinalizedBlockNumber() (uint32, error) {
-	hash, err := this.FinalizedBlockHash()
+func (c *Client) FinalizedBlockNumber() (uint32, error) {
+	hash, err := c.FinalizedBlockHash()
 	if err != nil {
 		return uint32(0), err
 	}
-	header, err := this.Rpc.Chain.GetHeader(prim.Some(hash))
+	header, err := c.Rpc.Chain.GetHeader(prim.Some(hash))
 	return header.Number, err
 }
 
-func (this *Client) BlockHash(blockNumber uint32) (prim.H256, error) {
-	return this.Rpc.Chain.GetBlockHash(prim.Some(blockNumber))
+func (c *Client) BlockHash(blockNumber uint32) (prim.H256, error) {
+	return c.Rpc.Chain.GetBlockHash(prim.Some(blockNumber))
 }
 
-func (this *Client) BestBlockHash() (prim.H256, error) {
-	return this.Rpc.Chain.GetBlockHash(prim.None[uint32]())
+func (c *Client) BestBlockHash() (prim.H256, error) {
+	return c.Rpc.Chain.GetBlockHash(prim.None[uint32]())
 }
 
-func (this *Client) FinalizedBlockHash() (prim.H256, error) {
-	return this.Rpc.Chain.GetFinalizedHead()
+func (c *Client) FinalizedBlockHash() (prim.H256, error) {
+	return c.Rpc.Chain.GetFinalizedHead()
 }
 
-func (this *Client) TransactionState(txHash prim.H256, finalized bool) ([]meta.TransactionState, error) {
-	return this.Rpc.Transaction.State(txHash, finalized)
+func (c *Client) TransactionState(txHash prim.H256, finalized bool) ([]meta.TransactionState, error) {
+	return c.Rpc.Transaction.State(txHash, finalized)
 }
 
-func (this *Client) EventsAt(at prim.Option[prim.H256]) (EventRecords, error) {
-	eventsRaw, err := this.Rpc.State.GetEvents(at)
+func (c *Client) EventsAt(at prim.Option[prim.H256]) (EventRecords, error) {
+	eventsRaw, err := c.Rpc.State.GetEvents(at)
 	if err != nil {
 		return EventRecords{}, err
 	}
-	events, err := NewEvents(prim.Hex.FromHex(eventsRaw), this.Metadata())
+	events, err := NewEvents(prim.Hex.FromHex(eventsRaw), c.Metadata())
 	if err != nil {
 		return EventRecords{}, err
 	}
@@ -88,9 +88,9 @@ func (this *Client) EventsAt(at prim.Option[prim.H256]) (EventRecords, error) {
 	return eventRecord, nil
 }
 
-func (this *Client) StorageAt(at prim.Option[prim.H256]) (BlockStorage, error) {
+func (c *Client) StorageAt(at prim.Option[prim.H256]) (BlockStorage, error) {
 	if at.IsNone() {
-		hash, err := this.Rpc.Chain.GetBlockHash(prim.None[uint32]())
+		hash, err := c.Rpc.Chain.GetBlockHash(prim.None[uint32]())
 		if err != nil {
 			return BlockStorage{}, err
 		}
@@ -98,21 +98,21 @@ func (this *Client) StorageAt(at prim.Option[prim.H256]) (BlockStorage, error) {
 	}
 
 	return BlockStorage{
-		client: this,
+		client: c,
 		at:     at.Unwrap(),
 	}, nil
 }
 
-func (this *Client) RPCBlockAt(blockHash prim.Option[prim.H256]) (RPCBlock, error) {
-	primBlock, err := this.Rpc.Chain.GetBlock(blockHash)
+func (c *Client) RPCBlockAt(blockHash prim.Option[prim.H256]) (RPCBlock, error) {
+	primBlock, err := c.Rpc.Chain.GetBlock(blockHash)
 	if err != nil {
 		return RPCBlock{}, err
 	}
 	return NewRPCBlockFromPrimBlock(primBlock)
 }
 
-func (this *Client) InitMetadata(at prim.Option[prim.H256]) error {
-	scaleMetadata, err := this.Rpc.State.GetMetadata(at)
+func (c *Client) InitMetadata(at prim.Option[prim.H256]) error {
+	scaleMetadata, err := c.Rpc.State.GetMetadata(at)
 	if err != nil {
 		return err
 	}
@@ -121,30 +121,30 @@ func (this *Client) InitMetadata(at prim.Option[prim.H256]) error {
 		return err
 	}
 
-	this.metadata = &metadata
+	c.metadata = &metadata
 	return nil
 }
 
-func (this *Client) InitRuntimeVersion(at prim.Option[prim.H256]) error {
-	runtimeVersion, err := this.Rpc.State.GetRuntimeVersion(at)
+func (c *Client) InitRuntimeVersion(at prim.Option[prim.H256]) error {
+	runtimeVersion, err := c.Rpc.State.GetRuntimeVersion(at)
 	if err != nil {
 		return err
 	}
-	this.RuntimeVersion = &runtimeVersion
+	c.RuntimeVersion = &runtimeVersion
 
-	genesisHash, err := this.Rpc.ChainSpec.V1GenesisHash()
+	genesisHash, err := c.Rpc.ChainSpec.V1GenesisHash()
 	if err != nil {
 		return err
 	}
-	this.GenesisHash = &genesisHash
+	c.GenesisHash = &genesisHash
 
 	return nil
 }
 
-func (this *Client) RequestWithRetry(method string, params string) (string, error) {
+func (c *Client) RequestWithRetry(method string, params string) (string, error) {
 	retryCount := 3
 	for {
-		res, err := this.Request(method, params)
+		res, err := c.Request(method, params)
 		if err != nil {
 			var sdkError *SDKError
 			if !errors.As(err, &sdkError) || sdkError.Code != 0 {
@@ -170,8 +170,8 @@ func (this *Client) RequestWithRetry(method string, params string) (string, erro
 	}
 }
 
-func (this *Client) Request(method string, params string) (prim.Option[string], error) {
-	responseBodyBytes, err := this.RequestRaw(method, params)
+func (c *Client) Request(method string, params string) (prim.Option[string], error) {
+	responseBodyBytes, err := c.RequestRaw(method, params)
 	if err != nil {
 		return prim.None[string](), err
 	}
@@ -212,7 +212,7 @@ func (this *Client) Request(method string, params string) (prim.Option[string], 
 	return prim.Some(result), nil
 }
 
-func (this *Client) RequestRaw(method string, params string) ([]byte, error) {
+func (c *Client) RequestRaw(method string, params string) ([]byte, error) {
 	rawJSON := []byte(`{
 		"id": 1,
 		"jsonrpc": "2.0",
@@ -223,13 +223,13 @@ func (this *Client) RequestRaw(method string, params string) ([]byte, error) {
 	requestBodyString := fmt.Sprintf(string(rawJSON), method, params)
 	requestBodyBytes := []byte(requestBodyString)
 
-	request, err := http.NewRequest("POST", this.endpoint, bytes.NewBuffer(requestBodyBytes))
+	request, err := http.NewRequest("POST", c.endpoint, bytes.NewBuffer(requestBodyBytes))
 	if err != nil {
 		return []byte{}, err
 	}
 
 	request.Header.Add("Content-Type", "application/json")
-	response, err := this.client.Do(request)
+	response, err := c.client.Do(request)
 	if err != nil {
 		return []byte{}, newError(err, ErrorCode000)
 	}
@@ -253,12 +253,12 @@ func (this *Client) RequestRaw(method string, params string) ([]byte, error) {
 	return responseBodyBytes, nil
 }
 
-func (this *Client) Send(tx prim.EncodedExtrinsic) (prim.H256, error) {
-	return this.Rpc.Author.SubmitExtrinsic(tx.ToHexWith0x())
+func (c *Client) Send(tx prim.EncodedExtrinsic) (prim.H256, error) {
+	return c.Rpc.Author.SubmitExtrinsic(tx.ToHexWith0x())
 }
 
-func (this *Client) Metadata() *meta.Metadata {
-	return this.metadata
+func (c *Client) Metadata() *meta.Metadata {
+	return c.metadata
 }
 
 type RPCBlock struct {

--- a/sdk/errors.go
+++ b/sdk/errors.go
@@ -8,8 +8,8 @@ type SDKError struct {
 	Message string
 }
 
-func (this SDKError) Error() string {
-	return fmt.Sprintf(`Code: %v; Meaning: %v; Message: %v`, this.Code, this.Meaning, this.Message)
+func (e SDKError) Error() string {
+	return fmt.Sprintf(`Code: %v; Meaning: %v; Message: %v`, e.Code, e.Meaning, e.Message)
 }
 
 var ErrorCode000 = SDKError{Code: 0, Meaning: "Failed to send request to Node. Node might be offline", Message: ""}

--- a/sdk/events.go
+++ b/sdk/events.go
@@ -45,17 +45,17 @@ func NewEvents(eventBytes []byte, metadata *meta.Metadata) (Events, error) {
 	return events, nil
 }
 
-func (this *Events) Decode() (EventRecords, error) {
+func (e *Events) Decode() (EventRecords, error) {
 	result := EventRecords{}
 	position := 0
 
-	if this.eventCount == 0 {
+	if e.eventCount == 0 {
 		return EventRecords{}, nil
 	}
 
-	decoder := prim.NewDecoder(this.eventBytes, int(this.startIdx))
+	decoder := prim.NewDecoder(e.eventBytes, int(e.startIdx))
 	for {
-		eventRecord, err := NewEventRecord(&decoder, uint32(position), this.metadata)
+		eventRecord, err := NewEventRecord(&decoder, uint32(position), e.metadata)
 		if err != nil {
 			return EventRecords{}, err
 		}
@@ -63,7 +63,7 @@ func (this *Events) Decode() (EventRecords, error) {
 		result = append(result, eventRecord)
 		position += 1
 
-		if position == int(this.eventCount) {
+		if position == int(e.eventCount) {
 			break
 		}
 	}
@@ -81,8 +81,8 @@ type EventPhase struct {
 	ApplyExtrinsic prim.Option[uint32]
 }
 
-func (this *EventPhase) ToString() string {
-	switch this.VariantIndex {
+func (e *EventPhase) ToString() string {
+	switch e.VariantIndex {
 	case 0:
 		return "ApplyExtrinsic"
 	case 1:
@@ -141,12 +141,12 @@ type EventRecord struct {
 	Topics   []prim.H256
 }
 
-func (this *EventRecord) TxIndex() prim.Option[uint32] {
-	if this.Phase.ApplyExtrinsic.IsNone() {
+func (e *EventRecord) TxIndex() prim.Option[uint32] {
+	if e.Phase.ApplyExtrinsic.IsNone() {
 		return prim.None[uint32]()
 	}
 
-	return prim.Some(this.Phase.ApplyExtrinsic.Unwrap())
+	return prim.Some(e.Phase.ApplyExtrinsic.Unwrap())
 }
 
 func NewEventRecord(decoder *prim.Decoder, position uint32, metadata *meta.Metadata) (EventRecord, error) {

--- a/sdk/logger.go
+++ b/sdk/logger.go
@@ -32,53 +32,53 @@ func NewCustomLoggerEmpty(marker string, enabled bool) CustomLogger {
 	}
 }
 
-func (this *CustomLogger) Enabled(value bool) {
-	this.enabled = value
+func (l *CustomLogger) Enabled(value bool) {
+	l.enabled = value
 }
 
-func (this *CustomLogger) LogWatcherRun(waitFor uint8, blockHeightTimeout uint32) {
-	if !logrus.IsLevelEnabled(logrus.DebugLevel) || !this.enabled {
+func (l *CustomLogger) LogWatcherRun(waitFor uint8, blockHeightTimeout uint32) {
+	if !logrus.IsLevelEnabled(logrus.DebugLevel) || !l.enabled {
 		return
 	}
 
-	logrus.Debug(fmt.Sprintf("%v: Watching for Tx Hash: %v. Waiting for: %v, Block height timeout: %v", this.marker, this.txHash, waitFor, blockHeightTimeout))
+	logrus.Debug(fmt.Sprintf("%v: Watching for Tx Hash: %v. Waiting for: %v, Block height timeout: %v", l.marker, l.txHash, waitFor, blockHeightTimeout))
 }
 
-func (this *CustomLogger) LogWatcherNewBlock(block *RPCBlock, blockHash prim.H256) {
-	if !logrus.IsLevelEnabled(logrus.DebugLevel) || !this.enabled {
+func (l *CustomLogger) LogWatcherNewBlock(block *RPCBlock, blockHash prim.H256) {
+	if !logrus.IsLevelEnabled(logrus.DebugLevel) || !l.enabled {
 		return
 	}
 
-	logrus.Debug(fmt.Sprintf("%v: New block fetched. Hash: %v, Number: %v", this.marker, blockHash, block.Header.Number))
+	logrus.Debug(fmt.Sprintf("%v: New block fetched. Hash: %v, Number: %v", l.marker, blockHash, block.Header.Number))
 }
 
-func (this *CustomLogger) LogWatcherTxFound(details *TransactionDetails) {
-	if !logrus.IsLevelEnabled(logrus.DebugLevel) || !this.enabled {
+func (l *CustomLogger) LogWatcherTxFound(details *TransactionDetails) {
+	if !logrus.IsLevelEnabled(logrus.DebugLevel) || !l.enabled {
 		return
 	}
 
-	logrus.Debug(fmt.Sprintf("%v: Transaction was found. Tx Hash: %v, Tx Index: %v, Block Hash: %v, Block Number: %v", this.marker, details.TxHash, details.TxIndex, details.BlockHash, details.BlockNumber))
+	logrus.Debug(fmt.Sprintf("%v: Transaction was found. Tx Hash: %v, Tx Index: %v, Block Hash: %v, Block Number: %v", l.marker, details.TxHash, details.TxIndex, details.BlockHash, details.BlockNumber))
 }
 
-func (this *CustomLogger) LogWatcherStop() {
-	if !logrus.IsLevelEnabled(logrus.DebugLevel) || !this.enabled {
+func (l *CustomLogger) LogWatcherStop() {
+	if !logrus.IsLevelEnabled(logrus.DebugLevel) || !l.enabled {
 		return
 	}
 
-	logrus.Debug(fmt.Sprintf("%v: No more blocks to search. Failed to find transaction. Tx Hash: %v", this.marker, this.txHash))
+	logrus.Debug(fmt.Sprintf("%v: No more blocks to search. Failed to find transaction. Tx Hash: %v", l.marker, l.txHash))
 }
 
-func (this *CustomLogger) LogTxSubmitted(keypair *subkey.KeyPair, mortality uint64) {
-	if !logrus.IsLevelEnabled(logrus.DebugLevel) || !this.enabled {
+func (l *CustomLogger) LogTxSubmitted(keypair *subkey.KeyPair, mortality uint64) {
+	if !logrus.IsLevelEnabled(logrus.DebugLevel) || !l.enabled {
 		return
 	}
 
 	address := (*keypair).SS58Address(42)
-	logrus.Debug(fmt.Sprintf("%v: Transaction was submitted. Account: %v, TxHash: %v, Mortality Period: %v", this.marker, address, this.txHash, mortality))
+	logrus.Debug(fmt.Sprintf("%v: Transaction was submitted. Account: %v, TxHash: %v, Mortality Period: %v", l.marker, address, l.txHash, mortality))
 }
 
-func (this *CustomLogger) LogTxSubmitting(keypair *subkey.KeyPair, payload *metadata.Payload, nonce uint32, appId uint32) {
-	if !logrus.IsLevelEnabled(logrus.DebugLevel) || !this.enabled {
+func (l *CustomLogger) LogTxSubmitting(keypair *subkey.KeyPair, payload *metadata.Payload, nonce uint32, appId uint32) {
+	if !logrus.IsLevelEnabled(logrus.DebugLevel) || !l.enabled {
 		return
 	}
 
@@ -86,26 +86,26 @@ func (this *CustomLogger) LogTxSubmitting(keypair *subkey.KeyPair, payload *meta
 	logrus.Debug(fmt.Sprintf("Signing and submitting new transaction. Account: %v, Nonce: %v, Pallet Name: %v, Call Name: %v, App Id: %v", address, nonce, payload.PalletName(), payload.CallName(), appId))
 }
 
-func (this *CustomLogger) LogTxRetryAbort() {
-	logrus.Warn(fmt.Sprintf("%v: Failed to submit and find transaction. Aborting. Tx Hash: %v", this.marker, this.txHash))
+func (l *CustomLogger) LogTxRetryAbort() {
+	logrus.Warn(fmt.Sprintf("%v: Failed to submit and find transaction. Aborting. Tx Hash: %v", l.marker, l.txHash))
 }
 
-func (this *CustomLogger) LogTxRetry() {
-	if !logrus.IsLevelEnabled(logrus.DebugLevel) || !this.enabled {
+func (l *CustomLogger) LogTxRetry() {
+	if !logrus.IsLevelEnabled(logrus.DebugLevel) || !l.enabled {
 		return
 	}
 
-	logrus.Debug(fmt.Sprintf("%v: Failed to submit and find transaction. Retrying.", this.marker))
+	logrus.Debug(fmt.Sprintf("%v: Failed to submit and find transaction. Retrying.", l.marker))
 }
 
-func (this *CustomLogger) LogRpcRetry(method string) {
-	if !logrus.IsLevelEnabled(logrus.DebugLevel) || !this.enabled {
+func (l *CustomLogger) LogRpcRetry(method string) {
+	if !logrus.IsLevelEnabled(logrus.DebugLevel) || !l.enabled {
 		return
 	}
 
-	logrus.Debug(fmt.Sprintf("%v: Failed to get concrete value from RPC call. Method: %v, Getting `null` as result. Retrying.", this.marker, method))
+	logrus.Debug(fmt.Sprintf("%v: Failed to get concrete value from RPC call. Method: %v, Getting `null` as result. Retrying.", l.marker, method))
 }
 
-func (this *CustomLogger) LogRpcRetryAbort(method string) {
-	logrus.Warn(fmt.Sprintf("%v: Failed to get concrete value from RPC call. Method: %v, Getting `null` as result. Aborting.", this.marker, method))
+func (l *CustomLogger) LogRpcRetryAbort(method string) {
+	logrus.Warn(fmt.Sprintf("%v: Failed to get concrete value from RPC call. Method: %v, Getting `null` as result. Aborting.", l.marker, method))
 }

--- a/sdk/rpc.go
+++ b/sdk/rpc.go
@@ -35,19 +35,19 @@ type RPCParams struct {
 	Values []string
 }
 
-func (this *RPCParams) Add(value string) {
-	this.Values = append(this.Values, value)
+func (r *RPCParams) Add(value string) {
+	r.Values = append(r.Values, value)
 }
 
-func (this *RPCParams) AddBool(value bool) {
+func (r *RPCParams) AddBool(value bool) {
 	if value == true {
-		this.Add("true")
+		r.Add("true")
 	} else {
-		this.Add("false")
+		r.Add("false")
 	}
 }
 
-func (this *RPCParams) AddByteSlice(value []byte) {
+func (r *RPCParams) AddByteSlice(value []byte) {
 	if len(value) == 0 {
 		return
 	}
@@ -63,26 +63,26 @@ func (this *RPCParams) AddByteSlice(value []byte) {
 
 	res = res + "]"
 
-	this.Values = append(this.Values, res)
+	r.Values = append(r.Values, res)
 }
 
-func (this *RPCParams) AddH256(value prim.H256) {
-	this.Add(value.ToRpcParam())
+func (r *RPCParams) AddH256(value prim.H256) {
+	r.Add(value.ToRpcParam())
 }
 
-func (this *RPCParams) AddUint32(value uint32) {
-	this.Add(strconv.FormatUint(uint64(value), 10))
+func (r *RPCParams) AddUint32(value uint32) {
+	r.Add(strconv.FormatUint(uint64(value), 10))
 }
 
-func (this *RPCParams) Build() string {
-	length := len(this.Values)
+func (r *RPCParams) Build() string {
+	length := len(r.Values)
 	if length == 0 {
 		return "[]"
 	}
 
 	result := "["
 	for i := 0; i < length; i++ {
-		result += this.Values[i]
+		result += r.Values[i]
 		if i < (length - 1) {
 			result += ", "
 		}

--- a/sdk/rpc_author.go
+++ b/sdk/rpc_author.go
@@ -10,20 +10,20 @@ type authorRPC struct {
 	client *Client
 }
 
-func (this *authorRPC) RotateKeys() (string, error) {
+func (a *authorRPC) RotateKeys() (string, error) {
 	params := RPCParams{}
-	return this.client.RequestWithRetry("author_rotateKeys", params.Build())
+	return a.client.RequestWithRetry("author_rotateKeys", params.Build())
 }
 
 // Transaction needs to be hex and scale encoded
-func (this *authorRPC) SubmitExtrinsic(tx string) (prim.H256, error) {
+func (a *authorRPC) SubmitExtrinsic(tx string) (prim.H256, error) {
 	if !strings.HasPrefix(tx, "0x") {
 		tx = "0x" + tx
 	}
 	params := RPCParams{}
 	params.Add("\"" + tx + "\"")
 
-	txHash, err := this.client.RequestWithRetry("author_submitExtrinsic", params.Build())
+	txHash, err := a.client.RequestWithRetry("author_submitExtrinsic", params.Build())
 	if err != nil {
 		return prim.H256{}, err
 	}

--- a/sdk/rpc_chain.go
+++ b/sdk/rpc_chain.go
@@ -10,13 +10,13 @@ type chainRPC struct {
 	client *Client
 }
 
-func (this *chainRPC) GetBlock(blockHash prim.Option[prim.H256]) (prim.Block, error) {
+func (c *chainRPC) GetBlock(blockHash prim.Option[prim.H256]) (prim.Block, error) {
 	params := RPCParams{}
 	if blockHash.IsSome() {
 		params.AddH256(blockHash.Unwrap())
 	}
 
-	value, err := this.client.RequestWithRetry("chain_getBlock", params.Build())
+	value, err := c.client.RequestWithRetry("chain_getBlock", params.Build())
 
 	if err != nil {
 		fmt.Println(fmt.Sprintf("Value: %v, Error: %v", value, err))
@@ -26,13 +26,13 @@ func (this *chainRPC) GetBlock(blockHash prim.Option[prim.H256]) (prim.Block, er
 	return prim.NewBlock(value)
 }
 
-func (this *chainRPC) GetBlockHash(blockNumber prim.Option[uint32]) (prim.H256, error) {
+func (c *chainRPC) GetBlockHash(blockNumber prim.Option[uint32]) (prim.H256, error) {
 	params := RPCParams{}
 	if blockNumber.IsSome() {
 		params.AddUint32(blockNumber.Unwrap())
 	}
 
-	value, err := this.client.RequestWithRetry("chain_getBlockHash", params.Build())
+	value, err := c.client.RequestWithRetry("chain_getBlockHash", params.Build())
 	if err != nil {
 		return prim.H256{}, err
 	}
@@ -40,10 +40,10 @@ func (this *chainRPC) GetBlockHash(blockNumber prim.Option[uint32]) (prim.H256, 
 	return prim.NewH256FromHexString(value)
 }
 
-func (this *chainRPC) GetFinalizedHead() (prim.H256, error) {
+func (c *chainRPC) GetFinalizedHead() (prim.H256, error) {
 	params := RPCParams{}
 
-	value, err := this.client.RequestWithRetry("chain_getFinalizedHead", params.Build())
+	value, err := c.client.RequestWithRetry("chain_getFinalizedHead", params.Build())
 	if err != nil {
 		return prim.H256{}, err
 	}
@@ -52,13 +52,13 @@ func (this *chainRPC) GetFinalizedHead() (prim.H256, error) {
 
 }
 
-func (this *chainRPC) GetHeader(blockHash prim.Option[prim.H256]) (prim.Header, error) {
+func (c *chainRPC) GetHeader(blockHash prim.Option[prim.H256]) (prim.Header, error) {
 	params := RPCParams{}
 	if blockHash.IsSome() {
 		params.AddH256(blockHash.Unwrap())
 	}
 
-	value, err := this.client.RequestWithRetry("chain_getHeader", params.Build())
+	value, err := c.client.RequestWithRetry("chain_getHeader", params.Build())
 	if err != nil {
 		return prim.Header{}, err
 	}

--- a/sdk/rpc_chain_spec.go
+++ b/sdk/rpc_chain_spec.go
@@ -8,9 +8,9 @@ type chainSpecRPC struct {
 	client *Client
 }
 
-func (this *chainSpecRPC) V1GenesisHash() (prim.H256, error) {
+func (c *chainSpecRPC) V1GenesisHash() (prim.H256, error) {
 	params := RPCParams{}
-	value, err := this.client.RequestWithRetry("chainSpec_v1_genesisHash", params.Build())
+	value, err := c.client.RequestWithRetry("chainSpec_v1_genesisHash", params.Build())
 	if err != nil {
 		return prim.H256{}, err
 	}

--- a/sdk/rpc_kate.go
+++ b/sdk/rpc_kate.go
@@ -14,13 +14,13 @@ type kateRPC struct {
 	client *Client
 }
 
-func (this *kateRPC) BlockLength(blockHash prim.Option[prim.H256]) (metadata.BlockLength, error) {
+func (k *kateRPC) BlockLength(blockHash prim.Option[prim.H256]) (metadata.BlockLength, error) {
 	var params = &RPCParams{}
 	if blockHash.IsSome() {
 		params.AddH256(blockHash.Unwrap())
 	}
 
-	rawJson, err := this.client.RequestWithRetry("kate_blockLength", params.Build())
+	rawJson, err := k.client.RequestWithRetry("kate_blockLength", params.Build())
 	if err != nil {
 		return metadata.BlockLength{}, err
 	}
@@ -58,7 +58,7 @@ func (this *kateRPC) BlockLength(blockHash prim.Option[prim.H256]) (metadata.Blo
 	return res, nil
 }
 
-func (this *kateRPC) QueryDataProof(transactionIndex uint32, blockHash prim.Option[prim.H256]) (metadata.ProofResponse, error) {
+func (k *kateRPC) QueryDataProof(transactionIndex uint32, blockHash prim.Option[prim.H256]) (metadata.ProofResponse, error) {
 	res := metadata.ProofResponse{}
 	var params = &RPCParams{}
 	params.AddUint32(transactionIndex)
@@ -66,7 +66,7 @@ func (this *kateRPC) QueryDataProof(transactionIndex uint32, blockHash prim.Opti
 		params.AddH256(blockHash.Unwrap())
 	}
 
-	rawJson, err := this.client.RequestWithRetry("kate_queryDataProof", params.Build())
+	rawJson, err := k.client.RequestWithRetry("kate_queryDataProof", params.Build())
 	if err != nil {
 		return res, err
 	}
@@ -221,7 +221,7 @@ func (this *kateRPC) QueryDataProof(transactionIndex uint32, blockHash prim.Opti
 	return res, nil
 }
 
-func (this *kateRPC) QueryProof(cells []KateCell, blockHash prim.Option[prim.H256]) ([]GDataProof, error) {
+func (k *kateRPC) QueryProof(cells []KateCell, blockHash prim.Option[prim.H256]) ([]GDataProof, error) {
 	var params = &RPCParams{}
 	res := []GDataProof{}
 
@@ -239,7 +239,7 @@ func (this *kateRPC) QueryProof(cells []KateCell, blockHash prim.Option[prim.H25
 		params.AddH256(blockHash.Unwrap())
 	}
 
-	rawJson, err := this.client.RequestWithRetry("kate_queryProof", params.Build())
+	rawJson, err := k.client.RequestWithRetry("kate_queryProof", params.Build())
 	if err != nil {
 		return res, err
 	}
@@ -275,7 +275,7 @@ type KateCell struct {
 
 type GDataProof = metadata.Tuple2[string, [48]byte]
 
-func (this *kateRPC) QueryRows(rows []uint32, blockHash prim.Option[prim.H256]) ([][]string, error) {
+func (k *kateRPC) QueryRows(rows []uint32, blockHash prim.Option[prim.H256]) ([][]string, error) {
 	var params = &RPCParams{}
 	res := [][]string{}
 
@@ -293,7 +293,7 @@ func (this *kateRPC) QueryRows(rows []uint32, blockHash prim.Option[prim.H256]) 
 		params.AddH256(blockHash.Unwrap())
 	}
 
-	rawJson, err := this.client.RequestWithRetry("kate_queryRows", params.Build())
+	rawJson, err := k.client.RequestWithRetry("kate_queryRows", params.Build())
 	if err != nil {
 		return res, err
 	}

--- a/sdk/rpc_state.go
+++ b/sdk/rpc_state.go
@@ -11,13 +11,13 @@ type stateRPC struct {
 	client *Client
 }
 
-func (this *stateRPC) GetRuntimeVersion(blockHash prim.Option[prim.H256]) (prim.RuntimeVersion, error) {
+func (s *stateRPC) GetRuntimeVersion(blockHash prim.Option[prim.H256]) (prim.RuntimeVersion, error) {
 	var params = &RPCParams{}
 	if blockHash.IsSome() {
 		params.AddH256(blockHash.Unwrap())
 	}
 
-	value, err := this.client.RequestWithRetry("state_getRuntimeVersion", params.Build())
+	value, err := s.client.RequestWithRetry("state_getRuntimeVersion", params.Build())
 	if err != nil {
 		return prim.RuntimeVersion{}, err
 	}
@@ -25,24 +25,24 @@ func (this *stateRPC) GetRuntimeVersion(blockHash prim.Option[prim.H256]) (prim.
 	return prim.NewRuntimeVersionFromJson(value)
 }
 
-func (this *stateRPC) GetStorage(key string, at prim.Option[prim.H256]) (prim.Option[string], error) {
+func (s *stateRPC) GetStorage(key string, at prim.Option[prim.H256]) (prim.Option[string], error) {
 	params := RPCParams{}
 	params.Add("\"" + key + "\"")
 	if at.IsSome() {
 		params.AddH256(at.Unwrap())
 	}
 
-	return this.client.Request("state_getStorage", params.Build())
+	return s.client.Request("state_getStorage", params.Build())
 }
 
-func (this *stateRPC) GetKeys(key string, at prim.Option[prim.H256]) ([]string, error) {
+func (s *stateRPC) GetKeys(key string, at prim.Option[prim.H256]) ([]string, error) {
 	params := RPCParams{}
 	params.Add("\"" + key + "\"")
 	if at.IsSome() {
 		params.AddH256(at.Unwrap())
 	}
 
-	value, err := this.client.RequestWithRetry("state_getKeys", params.Build())
+	value, err := s.client.RequestWithRetry("state_getKeys", params.Build())
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (this *stateRPC) GetKeys(key string, at prim.Option[prim.H256]) ([]string, 
 	return res, nil
 }
 
-func (this *stateRPC) GetKeysPaged(key string, count uint32, startKey prim.Option[string], at prim.Option[prim.H256]) ([]string, error) {
+func (s *stateRPC) GetKeysPaged(key string, count uint32, startKey prim.Option[string], at prim.Option[prim.H256]) ([]string, error) {
 	params := RPCParams{}
 	params.Add("\"" + key + "\"")
 	params.Add(fmt.Sprintf(`%v`, count))
@@ -68,7 +68,7 @@ func (this *stateRPC) GetKeysPaged(key string, count uint32, startKey prim.Optio
 		params.AddH256(at.Unwrap())
 	}
 
-	value, err := this.client.RequestWithRetry("state_getKeysPaged", params.Build())
+	value, err := s.client.RequestWithRetry("state_getKeysPaged", params.Build())
 	if err != nil {
 		return nil, err
 	}
@@ -81,26 +81,26 @@ func (this *stateRPC) GetKeysPaged(key string, count uint32, startKey prim.Optio
 	return res, nil
 }
 
-func (this *stateRPC) GetMetadata(at prim.Option[prim.H256]) (string, error) {
+func (s *stateRPC) GetMetadata(at prim.Option[prim.H256]) (string, error) {
 	params := RPCParams{}
 	if at.IsSome() {
 		params.AddH256(at.Unwrap())
 	}
 
-	return this.client.RequestWithRetry("state_getMetadata", params.Build())
+	return s.client.RequestWithRetry("state_getMetadata", params.Build())
 }
 
-func (this *stateRPC) GetEvents(at prim.Option[prim.H256]) (string, error) {
+func (s *stateRPC) GetEvents(at prim.Option[prim.H256]) (string, error) {
 	params := RPCParams{}
 	params.Add("\"" + "0x26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7" + "\"")
 	if at.IsSome() {
 		params.AddH256(at.Unwrap())
 	}
 
-	return this.client.RequestWithRetry("state_getStorage", params.Build())
+	return s.client.RequestWithRetry("state_getStorage", params.Build())
 }
 
-func (this *stateRPC) Call(method string, data string, at prim.Option[prim.H256]) (string, error) {
+func (s *stateRPC) Call(method string, data string, at prim.Option[prim.H256]) (string, error) {
 	params := RPCParams{}
 	params.Add("\"" + method + "\"")
 	params.Add("\"" + data + "\"")
@@ -108,5 +108,5 @@ func (this *stateRPC) Call(method string, data string, at prim.Option[prim.H256]
 		params.AddH256(at.Unwrap())
 	}
 
-	return this.client.RequestWithRetry("state_call", params.Build())
+	return s.client.RequestWithRetry("state_call", params.Build())
 }

--- a/sdk/rpc_system.go
+++ b/sdk/rpc_system.go
@@ -10,7 +10,7 @@ type systemRPC struct {
 	client *Client
 }
 
-func (this *systemRPC) AccountNextIndex(address string) (uint32, error) {
+func (s *systemRPC) AccountNextIndex(address string) (uint32, error) {
 	if len(address) < 1 {
 		return uint32(0), errors.New("Address needs to have a length of > 0")
 	}
@@ -26,7 +26,7 @@ func (this *systemRPC) AccountNextIndex(address string) (uint32, error) {
 	params := RPCParams{}
 	params.Add(address)
 
-	value, err := this.client.RequestWithRetry("system_accountNextIndex", params.Build())
+	value, err := s.client.RequestWithRetry("system_accountNextIndex", params.Build())
 
 	if err != nil {
 		return uint32(0), err
@@ -39,19 +39,19 @@ func (this *systemRPC) AccountNextIndex(address string) (uint32, error) {
 	return uint32(parsedValue), nil
 }
 
-func (this *systemRPC) Chain() (string, error) {
+func (s *systemRPC) Chain() (string, error) {
 	params := RPCParams{}
-	return this.client.RequestWithRetry("system_chain", params.Build())
+	return s.client.RequestWithRetry("system_chain", params.Build())
 }
 
-func (this *systemRPC) ChainType() (string, error) {
+func (s *systemRPC) ChainType() (string, error) {
 	params := RPCParams{}
-	return this.client.RequestWithRetry("system_chainType", params.Build())
+	return s.client.RequestWithRetry("system_chainType", params.Build())
 }
 
-func (this *systemRPC) Health() (RpcSystemHealth, error) {
+func (s *systemRPC) Health() (RpcSystemHealth, error) {
 	params := RPCParams{}
-	val, err := this.client.RequestWithRetry("system_health", params.Build())
+	val, err := s.client.RequestWithRetry("system_health", params.Build())
 	if err != nil {
 		return RpcSystemHealth{}, err
 	}
@@ -85,19 +85,19 @@ type RpcSystemHealth struct {
 	ShouldHavePeers bool
 }
 
-func (this *systemRPC) LocalPeerId() (string, error) {
+func (s *systemRPC) LocalPeerId() (string, error) {
 	params := RPCParams{}
-	return this.client.RequestWithRetry("system_localPeerId", params.Build())
+	return s.client.RequestWithRetry("system_localPeerId", params.Build())
 }
 
-func (this *systemRPC) Name() (string, error) {
+func (s *systemRPC) Name() (string, error) {
 	params := RPCParams{}
-	return this.client.RequestWithRetry("system_name", params.Build())
+	return s.client.RequestWithRetry("system_name", params.Build())
 }
 
-func (this *systemRPC) NodeRoles() ([]string, error) {
+func (s *systemRPC) NodeRoles() ([]string, error) {
 	params := RPCParams{}
-	val, err := this.client.RequestWithRetry("system_nodeRoles", params.Build())
+	val, err := s.client.RequestWithRetry("system_nodeRoles", params.Build())
 	if err != nil {
 		return []string{}, err
 	}
@@ -115,9 +115,9 @@ func (this *systemRPC) NodeRoles() ([]string, error) {
 	return res, nil
 }
 
-func (this *systemRPC) Properties() (RpcSystemChainProperties, error) {
+func (s *systemRPC) Properties() (RpcSystemChainProperties, error) {
 	params := RPCParams{}
-	val, err := this.client.RequestWithRetry("system_properties", params.Build())
+	val, err := s.client.RequestWithRetry("system_properties", params.Build())
 	if err != nil {
 		return RpcSystemChainProperties{}, err
 	}
@@ -158,9 +158,9 @@ type RpcSystemChainProperties struct {
 	TokenSymbol   string
 }
 
-func (this *systemRPC) SyncState() (RpcSystemSyncState, error) {
+func (s *systemRPC) SyncState() (RpcSystemSyncState, error) {
 	params := RPCParams{}
-	val, err := this.client.RequestWithRetry("system_syncState", params.Build())
+	val, err := s.client.RequestWithRetry("system_syncState", params.Build())
 	if err != nil {
 		return RpcSystemSyncState{}, err
 	}
@@ -194,8 +194,8 @@ type RpcSystemSyncState struct {
 	HighestBlock  uint32
 }
 
-func (this *systemRPC) Version() (string, error) {
+func (s *systemRPC) Version() (string, error) {
 	params := RPCParams{}
-	val, err := this.client.RequestWithRetry("system_version", params.Build())
+	val, err := s.client.RequestWithRetry("system_version", params.Build())
 	return val, err
 }

--- a/sdk/rpc_transcation.go
+++ b/sdk/rpc_transcation.go
@@ -12,12 +12,12 @@ type transactionRPC struct {
 	client *Client
 }
 
-func (this *transactionRPC) State(txHash primitives.H256, finalized bool) ([]metadata.TransactionState, error) {
+func (tr *transactionRPC) State(txHash primitives.H256, finalized bool) ([]metadata.TransactionState, error) {
 	params := RPCParams{}
 	params.Add(txHash.ToRpcParam())
 	params.AddBool(finalized)
 
-	value, err := this.client.RequestWithRetry("transaction_state", params.Build())
+	value, err := tr.client.RequestWithRetry("transaction_state", params.Build())
 	if err != nil {
 		return []metadata.TransactionState{}, err
 	}

--- a/sdk/runtime_api.go
+++ b/sdk/runtime_api.go
@@ -16,11 +16,11 @@ func newRuntimeAPi(client *Client) RuntimeApi {
 }
 
 // Parameter "tx" is hex encoded transaction.
-func (this *RuntimeApi) TransactionPaymentApi_queryInfo(tx string, at prim.Option[prim.H256]) (metadata.RuntimeDispatchInfo, error) {
+func (r *RuntimeApi) TransactionPaymentApi_queryInfo(tx string, at prim.Option[prim.H256]) (metadata.RuntimeDispatchInfo, error) {
 	encodedTxLen := len(prim.Hex.FromHex(tx))
 	encoded := tx + prim.Encoder.Encode(uint32(encodedTxLen))
 
-	val, err := this.client.Rpc.State.Call("TransactionPaymentApi_query_info", encoded, at)
+	val, err := r.client.Rpc.State.Call("TransactionPaymentApi_query_info", encoded, at)
 	if err != nil {
 		return metadata.RuntimeDispatchInfo{}, err
 	}
@@ -32,11 +32,11 @@ func (this *RuntimeApi) TransactionPaymentApi_queryInfo(tx string, at prim.Optio
 }
 
 // Parameter "tx" is hex encoded transaction.
-func (this *RuntimeApi) TransactionPaymentApi_queryFeeDetails(tx string, at prim.Option[prim.H256]) (metadata.FeeDetails, error) {
+func (r *RuntimeApi) TransactionPaymentApi_queryFeeDetails(tx string, at prim.Option[prim.H256]) (metadata.FeeDetails, error) {
 	encodedTxLen := len(prim.Hex.FromHex(tx))
 	encoded := tx + prim.Encoder.Encode(uint32(encodedTxLen))
 
-	val, err := this.client.Rpc.State.Call("TransactionPaymentApi_query_fee_details", encoded, at)
+	val, err := r.client.Rpc.State.Call("TransactionPaymentApi_query_fee_details", encoded, at)
 	if err != nil {
 		return metadata.FeeDetails{}, err
 	}
@@ -48,11 +48,11 @@ func (this *RuntimeApi) TransactionPaymentApi_queryFeeDetails(tx string, at prim
 }
 
 // Parameter "call" is hex encoded "primitive.call".
-func (this *RuntimeApi) TransactionPaymentCallApi_queryCallInfo(call string, at prim.Option[prim.H256]) (metadata.RuntimeDispatchInfo, error) {
+func (r *RuntimeApi) TransactionPaymentCallApi_queryCallInfo(call string, at prim.Option[prim.H256]) (metadata.RuntimeDispatchInfo, error) {
 	encodedTxLen := len(prim.Hex.FromHex(call))
 	encoded := call + prim.Encoder.Encode(uint32(encodedTxLen))
 
-	val, err := this.client.Rpc.State.Call("TransactionPaymentCallApi_query_call_info", encoded, at)
+	val, err := r.client.Rpc.State.Call("TransactionPaymentCallApi_query_call_info", encoded, at)
 	if err != nil {
 		return metadata.RuntimeDispatchInfo{}, err
 	}
@@ -64,11 +64,11 @@ func (this *RuntimeApi) TransactionPaymentCallApi_queryCallInfo(call string, at 
 }
 
 // Parameter "call" is hex encoded "primitive.call".
-func (this *RuntimeApi) TransactionPaymentCallApi_queryCallFeeDetails(call string, at prim.Option[prim.H256]) (metadata.FeeDetails, error) {
+func (r *RuntimeApi) TransactionPaymentCallApi_queryCallFeeDetails(call string, at prim.Option[prim.H256]) (metadata.FeeDetails, error) {
 	encodedTxLen := len(prim.Hex.FromHex(call))
 	encoded := call + prim.Encoder.Encode(uint32(encodedTxLen))
 
-	val, err := this.client.Rpc.State.Call("TransactionPaymentCallApi_query_call_fee_details", encoded, at)
+	val, err := r.client.Rpc.State.Call("TransactionPaymentCallApi_query_call_fee_details", encoded, at)
 	if err != nil {
 		return metadata.FeeDetails{}, err
 	}

--- a/sdk/sdk_transactions.go
+++ b/sdk/sdk_transactions.go
@@ -22,14 +22,14 @@ type DataAvailabilityTx struct {
 	client *Client
 }
 
-func (this *DataAvailabilityTx) SubmitData(data []byte) Transaction {
+func (dat *DataAvailabilityTx) SubmitData(data []byte) Transaction {
 	call := daPallet.CallSubmitData{Data: data}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(dat.client, pallets.ToPayload(call))
 }
 
-func (this *DataAvailabilityTx) CreateApplicationKey(key []byte) Transaction {
+func (dat *DataAvailabilityTx) CreateApplicationKey(key []byte) Transaction {
 	call := daPallet.CallCreateApplicationKey{Key: key}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(dat.client, pallets.ToPayload(call))
 }
 
 type UtilityTx struct {
@@ -39,27 +39,27 @@ type UtilityTx struct {
 // Send a batch of dispatch calls.
 //
 // May be called from any origin except `None`.
-func (this *UtilityTx) Batch(calls []prim.Call) Transaction {
+func (ut *UtilityTx) Batch(calls []prim.Call) Transaction {
 	call := utPallet.CallBatch{Calls: calls}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(ut.client, pallets.ToPayload(call))
 }
 
 // Send a batch of dispatch calls and atomically execute them.
 // The whole transaction will rollback and fail if any of the calls failed.
 //
 // May be called from any origin except `None`.
-func (this *UtilityTx) BatchAll(calls []prim.Call) Transaction {
+func (ut *UtilityTx) BatchAll(calls []prim.Call) Transaction {
 	call := utPallet.CallBatchAll{Calls: calls}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(ut.client, pallets.ToPayload(call))
 }
 
 // Send a batch of dispatch calls.
 // Unlike `batch`, it allows errors and won't interrupt.
 //
 // May be called from any origin except `None`.
-func (this *UtilityTx) ForceBatch(calls []prim.Call) Transaction {
+func (ut *UtilityTx) ForceBatch(calls []prim.Call) Transaction {
 	call := utPallet.CallForceBatch{Calls: calls}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(ut.client, pallets.ToPayload(call))
 }
 
 // Send a call through an indexed pseudonym of the sender.
@@ -71,9 +71,9 @@ func (this *UtilityTx) ForceBatch(calls []prim.Call) Transaction {
 // because you expect `proxy` to have been used prior in the call stack and you do not want
 // the call restrictions to apply to any sub-accounts), then use `as_multi_threshold_1`
 // in the Multisig pallet instead.
-func (this *UtilityTx) AsDerivate(index uint16, call prim.Call) Transaction {
+func (ut *UtilityTx) AsDerivate(index uint16, call prim.Call) Transaction {
 	c := utPallet.CallAsDerivate{Index: index, Call: call}
-	return NewTransaction(this.client, pallets.ToPayload(c))
+	return NewTransaction(ut.client, pallets.ToPayload(c))
 }
 
 type BalancesTx struct {
@@ -87,16 +87,16 @@ type BalancesTx struct {
 // of the transfer, the account will be reaped.
 //
 // The dispatch origin for this call must be `Signed` by the transactor.
-func (this *BalancesTx) TransferAllowDeath(dest prim.MultiAddress, amount metadata.Balance) Transaction {
+func (bt *BalancesTx) TransferAllowDeath(dest prim.MultiAddress, amount metadata.Balance) Transaction {
 	call := baPallet.CallTransferAlowDeath{Dest: dest, Value: amount.Value}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(bt.client, pallets.ToPayload(call))
 }
 
 // Exactly as `TransferAlowDeath`, except the origin must be root and the source account
 // may be specified
-func (this *BalancesTx) ForceTransfer(dest prim.MultiAddress, amount metadata.Balance) Transaction {
+func (bt *BalancesTx) ForceTransfer(dest prim.MultiAddress, amount metadata.Balance) Transaction {
 	call := baPallet.CallForceTransfer{Dest: dest, Value: amount}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(bt.client, pallets.ToPayload(call))
 }
 
 // Transfer the entire transferable balance from the caller account.
@@ -104,16 +104,16 @@ func (this *BalancesTx) ForceTransfer(dest prim.MultiAddress, amount metadata.Ba
 // NOTE: This function only attempts to transfer _transferable_ balances. This means that
 // any locked, reserved, or existential deposits (when `keep_alive` is `true`), will not be
 // transferred by this function.
-func (this *BalancesTx) TransferAll(dest prim.MultiAddress, keepAlive bool) Transaction {
+func (bt *BalancesTx) TransferAll(dest prim.MultiAddress, keepAlive bool) Transaction {
 	call := baPallet.CallTransferAll{Dest: dest, KeepAlive: keepAlive}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(bt.client, pallets.ToPayload(call))
 }
 
 // Same as the `TransferAlowDeath` call, but with a check that the transfer will not
 // kill the origin account.
-func (this *BalancesTx) TransferKeepAlive(dest prim.MultiAddress, amount metadata.Balance) Transaction {
+func (bt *BalancesTx) TransferKeepAlive(dest prim.MultiAddress, amount metadata.Balance) Transaction {
 	call := baPallet.CallTransferKeepAlive{Dest: dest, Value: amount}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(bt.client, pallets.ToPayload(call))
 }
 
 type StakingTx struct {
@@ -122,65 +122,65 @@ type StakingTx struct {
 
 // Take the origin account as a stash and lock up `value` of its balance. `controller` will
 // be the account that controls it.
-func (this *StakingTx) Bond(value metadata.Balance, payee metadata.RewardDestination) Transaction {
+func (st *StakingTx) Bond(value metadata.Balance, payee metadata.RewardDestination) Transaction {
 	call := stPallet.CallBond{Value: value, Payee: payee}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(st.client, pallets.ToPayload(call))
 }
 
 // Add some extra amount that have appeared in the stash `free_balance` into the balance up
 // for staking.
-func (this *StakingTx) BondExtra(maxAdditional metadata.Balance) Transaction {
+func (st *StakingTx) BondExtra(maxAdditional metadata.Balance) Transaction {
 	call := stPallet.CallBondExtra{MaxAdditional: maxAdditional}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(st.client, pallets.ToPayload(call))
 }
 
 // Schedule a portion of the stash to be unlocked ready for transfer out after the bond
 // period ends. If this leaves an amount actively bonded less than
 // T::Currency::minimum_balance(), then it is increased to the full amount.
-func (this *StakingTx) Unbond(value metadata.Balance) Transaction {
+func (st *StakingTx) Unbond(value metadata.Balance) Transaction {
 	call := stPallet.CallUnbond{Value: value}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(st.client, pallets.ToPayload(call))
 }
 
 // Remove any unlocked chunks from the `unlocking` queue from our management.
 //
 // This essentially frees up that balance to be used by the stash account to do whatever
 // it wants.
-func (this *StakingTx) WithdrawUnbonded(numSlashingSpans uint32) Transaction {
+func (st *StakingTx) WithdrawUnbonded(numSlashingSpans uint32) Transaction {
 	call := stPallet.CallWithdrawUnbonded{NumSlashingSpans: numSlashingSpans}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(st.client, pallets.ToPayload(call))
 }
 
 // Declare the desire to validate for the origin controller.
 //
 // Effects will be felt at the beginning of the next era.
-func (this *StakingTx) Validate(prefs metadata.ValidatorPrefs) Transaction {
+func (st *StakingTx) Validate(prefs metadata.ValidatorPrefs) Transaction {
 	call := stPallet.CallValidate{Prefs: prefs}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(st.client, pallets.ToPayload(call))
 }
 
 // Declare the desire to nominate `targets` for the origin controller.
 //
 // Effects will be felt at the beginning of the next era.
-func (this *StakingTx) Nominate(targets []prim.MultiAddress) Transaction {
+func (st *StakingTx) Nominate(targets []prim.MultiAddress) Transaction {
 	call := stPallet.CallNominate{Targets: targets}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(st.client, pallets.ToPayload(call))
 }
 
 // Declare no desire to either validate or nominate.
 //
 // Effects will be felt at the beginning of the next era.
-func (this *StakingTx) Chill() Transaction {
+func (st *StakingTx) Chill() Transaction {
 	call := stPallet.CallChill{}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(st.client, pallets.ToPayload(call))
 }
 
 // (Re-)set the payment target for a controller.
 //
 // Effects will be felt instantly (as soon as this function is completed successfully).
-func (this *StakingTx) SetPayee(payee metadata.RewardDestination) Transaction {
+func (st *StakingTx) SetPayee(payee metadata.RewardDestination) Transaction {
 	call := stPallet.CallSetPayee{Payee: payee}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(st.client, pallets.ToPayload(call))
 }
 
 // (Re-)sets the controller of a stash to the stash itself. This function previously
@@ -189,24 +189,24 @@ func (this *StakingTx) SetPayee(payee metadata.RewardDestination) Transaction {
 // to the stash, if it is not already.
 //
 // Effects will be felt instantly (as soon as this function is completed successfully).
-func (this *StakingTx) SetController() Transaction {
+func (st *StakingTx) SetController() Transaction {
 	call := stPallet.CallSetController{}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(st.client, pallets.ToPayload(call))
 }
 
 // Pay out next page of the stakers behind a validator for the given era.
 //
 // - `validator_stash` is the stash account of the validator.
 // - `era` may be any era between `[current_era - history_depth; current_era]`.
-func (this *StakingTx) PayoutStakers(validatorStash prim.AccountId, era uint32) Transaction {
+func (st *StakingTx) PayoutStakers(validatorStash prim.AccountId, era uint32) Transaction {
 	call := stPallet.CallPayoutStakers{ValidatorStash: validatorStash, Era: era}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(st.client, pallets.ToPayload(call))
 }
 
 // Rebond a portion of the stash scheduled to be unlocked.
-func (this *StakingTx) Rebond(value uint128.Uint128) Transaction {
+func (st *StakingTx) Rebond(value uint128.Uint128) Transaction {
 	call := stPallet.CallRebond{Value: value}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(st.client, pallets.ToPayload(call))
 }
 
 // Remove all data structures concerning a staker/stash once it is at a state where it can
@@ -221,17 +221,17 @@ func (this *StakingTx) Rebond(value uint128.Uint128) Transaction {
 // It can be called by anyone, as long as `stash` meets the above requirements.
 //
 // Refunds the transaction fees upon successful execution.
-func (this *StakingTx) ReapStash(stash prim.AccountId, numSlashingSpans uint32) Transaction {
+func (st *StakingTx) ReapStash(stash prim.AccountId, numSlashingSpans uint32) Transaction {
 	call := stPallet.CallReapStash{Stash: stash, NumSlashingSpans: numSlashingSpans}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(st.client, pallets.ToPayload(call))
 }
 
 // Remove the given nominations from the calling validator.
 //
 // Effects will be felt at the beginning of the next era.
-func (this *StakingTx) Kick(who []prim.MultiAddress) Transaction {
+func (st *StakingTx) Kick(who []prim.MultiAddress) Transaction {
 	call := stPallet.CallKick{Who: who}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(st.client, pallets.ToPayload(call))
 }
 
 // Declare a `controller` to stop participating as either a validator or nominator.
@@ -260,17 +260,17 @@ func (this *StakingTx) Kick(who []prim.MultiAddress) Transaction {
 //
 // This can be helpful if bond requirements are updated, and we need to remove old users
 // who do not satisfy these requirements.
-func (this *StakingTx) ChillOther(stash prim.AccountId) Transaction {
+func (st *StakingTx) ChillOther(stash prim.AccountId) Transaction {
 	call := stPallet.CallChillOther{Stash: stash}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(st.client, pallets.ToPayload(call))
 }
 
 // Force a validator to have at least the minimum commission. This will not affect a
 // validator who already has a commission greater than or equal to the minimum. Any account
-// can call this.
-func (this *StakingTx) ForceApplyMinCommission(validatorStash prim.AccountId) Transaction {
+// can call s.
+func (st *StakingTx) ForceApplyMinCommission(validatorStash prim.AccountId) Transaction {
 	call := stPallet.CallForceApplyMinCommission{ValidatorStash: validatorStash}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(st.client, pallets.ToPayload(call))
 }
 
 // Pay out a page of the stakers behind a validator for the given era and page.
@@ -290,9 +290,9 @@ func (this *StakingTx) ForceApplyMinCommission(validatorStash prim.AccountId) Tr
 // backing a validator to receive the reward. The nominators are not sorted across pages
 // and so it should not be assumed the highest staker would be on the topmost page and vice
 // versa. If rewards are not claimed in [`Config::HistoryDepth`] eras, they are lost.
-func (this *StakingTx) PayoutStakersByPage(validatorStash prim.AccountId, era uint32, page uint32) Transaction {
+func (st *StakingTx) PayoutStakersByPage(validatorStash prim.AccountId, era uint32, page uint32) Transaction {
 	call := stPallet.CallPayoutStakersByPage{ValidatorStash: validatorStash, Era: era, Page: page}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(st.client, pallets.ToPayload(call))
 }
 
 // Migrates an account's `RewardDestination::Controller` to
@@ -301,9 +301,9 @@ func (this *StakingTx) PayoutStakersByPage(validatorStash prim.AccountId, era ui
 // Effects will be felt instantly (as soon as this function is completed successfully).
 //
 // This will waive the transaction fee if the `payee` is successfully migrated.
-func (this *StakingTx) UpdatePayee(controller prim.AccountId) Transaction {
+func (st *StakingTx) UpdatePayee(controller prim.AccountId) Transaction {
 	call := stPallet.CallUpdatePayee{Controller: controller}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(st.client, pallets.ToPayload(call))
 }
 
 type NominationPoolsTx struct {
@@ -320,9 +320,9 @@ type NominationPoolsTx struct {
 //   - This call will *not* dust the member account, so the member must have at least
 //     `existential deposit + amount` in their account.
 //   - Only a pool with [`PoolState::Open`] can be joined
-func (this *NominationPoolsTx) Join(amount metadata.Balance, poolId uint32) Transaction {
+func (npt *NominationPoolsTx) Join(amount metadata.Balance, poolId uint32) Transaction {
 	call := npPallet.CallJoin{Amount: amount, PoolId: poolId}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 // Bond `extra` more funds from `origin` into the pool to which they already belong.
@@ -332,9 +332,9 @@ func (this *NominationPoolsTx) Join(amount metadata.Balance, poolId uint32) Tran
 //
 // Bonding extra funds implies an automatic payout of all pending rewards as well.
 // See `bond_extra_other` to bond pending rewards of `other` members.
-func (this *NominationPoolsTx) BondExtra(extra metadata.PoolBondExtra) Transaction {
+func (npt *NominationPoolsTx) BondExtra(extra metadata.PoolBondExtra) Transaction {
 	call := npPallet.CallBondExtra{Extra: extra}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 // A bonded member can use this to claim their payout based on the rewards that the pool
@@ -345,9 +345,9 @@ func (this *NominationPoolsTx) BondExtra(extra metadata.PoolBondExtra) Transacti
 // members in the pools stake. Rewards do not "expire".
 //
 // See `claim_payout_other` to caim rewards on bahalf of some `other` pool member.
-func (this *NominationPoolsTx) ClaimPayout() Transaction {
+func (npt *NominationPoolsTx) ClaimPayout() Transaction {
 	call := npPallet.CallClaimPayout{}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 // Unbond up to `unbonding_points` of the `member_account`'s funds from the pool. It
@@ -381,9 +381,9 @@ func (this *NominationPoolsTx) ClaimPayout() Transaction {
 // are available). However, it may not be possible to release the current unlocking chunks,
 // in which case, the result of this call will likely be the `NoMoreChunks` error from the
 // staking system.
-func (this *NominationPoolsTx) Unbond(memberAccount prim.MultiAddress, unbondingPoints uint128.Uint128) Transaction {
+func (npt *NominationPoolsTx) Unbond(memberAccount prim.MultiAddress, unbondingPoints uint128.Uint128) Transaction {
 	call := npPallet.CallUnbond{MemberAccount: memberAccount, UnbondingPoints: unbondingPoints}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 // Call `withdraw_unbonded` for the pools account. This call can be made by any account.
@@ -392,9 +392,9 @@ func (this *NominationPoolsTx) Unbond(memberAccount prim.MultiAddress, unbonding
 // can be cleared by withdrawing. In the case there are too many unlocking chunks, the user
 // would probably see an error like `NoMoreChunks` emitted from the staking system when
 // they attempt to unbond.
-func (this *NominationPoolsTx) PoolWithdrawUnbonded(poolId uint32, numSlashingSpans uint32) Transaction {
+func (npt *NominationPoolsTx) PoolWithdrawUnbonded(poolId uint32, numSlashingSpans uint32) Transaction {
 	call := npPallet.CallPoolWithdrawUnbonded{PoolId: poolId, NumSlashingSpans: numSlashingSpans}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 // Withdraw unbonded funds from `member_account`. If no bonded funds can be unbonded, an
@@ -416,9 +416,9 @@ func (this *NominationPoolsTx) PoolWithdrawUnbonded(poolId uint32, numSlashingSp
 // # Note
 //
 // If the target is the depositor, the pool will be destroyed.
-func (this *NominationPoolsTx) WithdrawUnbonded(memberAccount prim.MultiAddress, numSlashingSpans uint32) Transaction {
+func (npt *NominationPoolsTx) WithdrawUnbonded(memberAccount prim.MultiAddress, numSlashingSpans uint32) Transaction {
 	call := npPallet.CallWithdrawUnbonded{MemberAccount: memberAccount, NumSlashingSpans: numSlashingSpans}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 // Create a new delegation pool.
@@ -438,9 +438,9 @@ func (this *NominationPoolsTx) WithdrawUnbonded(memberAccount prim.MultiAddress,
 //
 // In addition to `amount`, the caller will transfer the existential deposit; so the caller
 // needs at have at least `amount + existential_deposit` transferable.
-func (this *NominationPoolsTx) Create(amount metadata.Balance, root prim.MultiAddress, nominator prim.MultiAddress, bouncer prim.MultiAddress) Transaction {
+func (npt *NominationPoolsTx) Create(amount metadata.Balance, root prim.MultiAddress, nominator prim.MultiAddress, bouncer prim.MultiAddress) Transaction {
 	call := npPallet.CallCreate{Amount: amount, Root: root, Nominator: nominator, Bouncer: bouncer}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 // Create a new delegation pool with a previously used pool id
@@ -449,9 +449,9 @@ func (this *NominationPoolsTx) Create(amount metadata.Balance, root prim.MultiAd
 //
 // same as `create` with the inclusion of
 // * `pool_id` - `A valid PoolId.
-func (this *NominationPoolsTx) CreateWithPoolId(amount metadata.Balance, root prim.MultiAddress, nominator prim.MultiAddress, bouncer prim.MultiAddress, poolId uint32) Transaction {
+func (npt *NominationPoolsTx) CreateWithPoolId(amount metadata.Balance, root prim.MultiAddress, nominator prim.MultiAddress, bouncer prim.MultiAddress, poolId uint32) Transaction {
 	call := npPallet.CallCreateWithPoolId{Amount: amount, Root: root, Nominator: nominator, Bouncer: bouncer, PoolId: poolId}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 // Nominate on behalf of the pool.
@@ -461,9 +461,9 @@ func (this *NominationPoolsTx) CreateWithPoolId(amount metadata.Balance, root pr
 //
 // This directly forward the call to the staking pallet, on behalf of the pool bonded
 // account.
-func (this *NominationPoolsTx) Nominate(poolId uint32, validators []prim.AccountId) Transaction {
+func (npt *NominationPoolsTx) Nominate(poolId uint32, validators []prim.AccountId) Transaction {
 	call := npPallet.CallNominate{PoolId: poolId, Validators: validators}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 // Set a new state for the pool.
@@ -476,18 +476,18 @@ func (this *NominationPoolsTx) Nominate(poolId uint32, validators []prim.Account
 //  1. signed by the bouncer, or the root role of the pool,
 //  2. if the pool conditions to be open are NOT met (as described by `ok_to_be_open`), and
 //     then the state of the pool can be permissionlessly changed to `Destroying`.
-func (this *NominationPoolsTx) SetState(poolId uint32, state metadata.PoolState) Transaction {
+func (npt *NominationPoolsTx) SetState(poolId uint32, state metadata.PoolState) Transaction {
 	call := npPallet.CallSetState{PoolId: poolId, State: state}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 // Set a new metadata for the pool.
 //
 // The dispatch origin of this call must be signed by the bouncer, or the root role of the
 // pool.
-func (this *NominationPoolsTx) SetMetadata(poolId uint32, metadata []byte) Transaction {
+func (npt *NominationPoolsTx) SetMetadata(poolId uint32, metadata []byte) Transaction {
 	call := npPallet.CallSetMetadata{PoolId: poolId, Metadata: metadata}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 // Update the roles of the pool.
@@ -497,9 +497,9 @@ func (this *NominationPoolsTx) SetMetadata(poolId uint32, metadata []byte) Trans
 //
 // It emits an event, notifying UIs of the role change. This event is quite relevant to
 // most pool members and they should be informed of changes to pool roles.
-func (this *NominationPoolsTx) UpdateRoles(poolId uint32, newRoot metadata.PoolRoleConfig, newNominator metadata.PoolRoleConfig, newBouncer metadata.PoolRoleConfig) Transaction {
+func (npt *NominationPoolsTx) UpdateRoles(poolId uint32, newRoot metadata.PoolRoleConfig, newNominator metadata.PoolRoleConfig, newBouncer metadata.PoolRoleConfig) Transaction {
 	call := npPallet.CallUpdateRoles{PoolId: poolId, NewRoot: newRoot, NewNominator: newNominator, NewBouncer: newBouncer}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 // Chill on behalf of the pool.
@@ -509,9 +509,9 @@ func (this *NominationPoolsTx) UpdateRoles(poolId uint32, newRoot metadata.PoolR
 //
 // This directly forward the call to the staking pallet, on behalf of the pool bonded
 // account.
-func (this *NominationPoolsTx) Chill(poolId uint32) Transaction {
+func (npt *NominationPoolsTx) Chill(poolId uint32) Transaction {
 	call := npPallet.CallChill{PoolId: poolId}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 // `origin` bonds funds from `extra` for some pool member `member` into their respective
@@ -523,9 +523,9 @@ func (this *NominationPoolsTx) Chill(poolId uint32) Transaction {
 // In the case of `origin != other`, `origin` can only bond extra pending rewards of
 // `other` members assuming set_claim_permission for the given member is
 // `PermissionlessAll` or `PermissionlessCompound`.
-func (this *NominationPoolsTx) BondExtraOther(member prim.MultiAddress, extra metadata.PoolBondExtra) Transaction {
+func (npt *NominationPoolsTx) BondExtraOther(member prim.MultiAddress, extra metadata.PoolBondExtra) Transaction {
 	call := npPallet.CallBondExtraOther{Member: member, Extra: extra}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 // Allows a pool member to set a claim permission to allow or disallow permissionless
@@ -540,18 +540,18 @@ func (this *NominationPoolsTx) BondExtraOther(member prim.MultiAddress, extra me
 //
 // * `origin` - Member of a pool.
 // * `actor` - Account to claim reward. // improve this
-func (this *NominationPoolsTx) SetClaimPermission(permission metadata.PoolClaimPermission) Transaction {
+func (npt *NominationPoolsTx) SetClaimPermission(permission metadata.PoolClaimPermission) Transaction {
 	call := npPallet.CallSetClaimPermission{Permission: permission}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 // `origin` can claim payouts on some pool member `other`'s behalf.
 //
 // Pool member `other` must have a `PermissionlessAll` or `PermissionlessWithdraw` in order
 // for this call to be successful.
-func (this *NominationPoolsTx) ClaimPayoutOther(other prim.AccountId) Transaction {
+func (npt *NominationPoolsTx) ClaimPayoutOther(other prim.AccountId) Transaction {
 	call := npPallet.CallClaimPayoutOther{Other: other}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 // Set the commission of a pool.
@@ -560,9 +560,9 @@ func (this *NominationPoolsTx) ClaimPayoutOther(other prim.AccountId) Transactio
 // tuple. Where a `current` of `None` is provided, any current commission will be removed.
 //
 // - If a `None` is supplied to `new_commission`, existing commission will be removed.
-func (this *NominationPoolsTx) SetCommission(poolId uint32, newCommission prim.Option[metadata.Tuple2[metadata.Perbill, prim.AccountId]]) Transaction {
+func (npt *NominationPoolsTx) SetCommission(poolId uint32, newCommission prim.Option[metadata.Tuple2[metadata.Perbill, prim.AccountId]]) Transaction {
 	call := npPallet.CallSetCommission{PoolId: poolId, NewCommission: newCommission}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 // Set the maximum commission of a pool.
@@ -570,18 +570,18 @@ func (this *NominationPoolsTx) SetCommission(poolId uint32, newCommission prim.O
 //   - Initial max can be set to any `Perbill`, and only smaller values thereafter.
 //   - Current commission will be lowered in the event it is higher than a new max
 //     commission.
-func (this *NominationPoolsTx) SetCommissionMax(poolId uint32, maxCommission metadata.Perbill) Transaction {
+func (npt *NominationPoolsTx) SetCommissionMax(poolId uint32, maxCommission metadata.Perbill) Transaction {
 	call := npPallet.CallSetCommissionMax{PoolId: poolId, MaxCommission: maxCommission}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 // Set the commission change rate for a pool.
 //
 // Initial change rate is not bounded, whereas subsequent updates can only be more
 // restrictive than the current.
-func (this *NominationPoolsTx) SetCommissionChangeRate(poolId uint32, changeRate metadata.PoolCommissionChangeRate) Transaction {
+func (npt *NominationPoolsTx) SetCommissionChangeRate(poolId uint32, changeRate metadata.PoolCommissionChangeRate) Transaction {
 	call := npPallet.CallSetCommissionChangeRate{PoolId: poolId, ChangeRate: changeRate}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 // Claim pending commission.
@@ -589,9 +589,9 @@ func (this *NominationPoolsTx) SetCommissionChangeRate(poolId uint32, changeRate
 // The dispatch origin of this call must be signed by the `root` role of the pool. Pending
 // commission is paid out and added to total claimed commission`. Total pending commission
 // is reset to zero. the current.
-func (this *NominationPoolsTx) ClaimCommission(poolId uint32) Transaction {
+func (npt *NominationPoolsTx) ClaimCommission(poolId uint32) Transaction {
 	call := npPallet.CallClaimCommission{PoolId: poolId}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 // Top up the deficit or withdraw the excess ED from the pool.
@@ -601,18 +601,18 @@ func (this *NominationPoolsTx) ClaimCommission(poolId uint32) Transaction {
 // insufficient to cover the ED deficit of the pool or vice-versa where there is excess
 // deposit to the pool. This call allows anyone to adjust the ED deposit of the
 // pool by either topping up the deficit or claiming the excess.
-func (this *NominationPoolsTx) AdjustPoolDeposit(poolId uint32) Transaction {
+func (npt *NominationPoolsTx) AdjustPoolDeposit(poolId uint32) Transaction {
 	call := npPallet.CallAdjustPoolDeposit{PoolId: poolId}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 // Set or remove a pool's commission claim permission.
 //
 // Determines who can claim the pool's pending commission. Only the `Root` role of the pool
 // is able to conifigure commission claim permissions.
-func (this *NominationPoolsTx) SetCommissionClaimPermission(poolId uint32, permission prim.Option[metadata.CommissionClaimPermission]) Transaction {
+func (npt *NominationPoolsTx) SetCommissionClaimPermission(poolId uint32, permission prim.Option[metadata.CommissionClaimPermission]) Transaction {
 	call := npPallet.CallSetCommissionClaimPermission{PoolId: poolId, Permission: permission}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(npt.client, pallets.ToPayload(call))
 }
 
 type SystemTx struct {
@@ -622,109 +622,109 @@ type SystemTx struct {
 // Make some on-chain remark.
 //
 // Can be executed by every `origin`
-func (this *SystemTx) Remark(remark []byte) Transaction {
+func (syt *SystemTx) Remark(remark []byte) Transaction {
 	call := syPallet.CallRemark{Remark: remark}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(syt.client, pallets.ToPayload(call))
 }
 
 // Make some on-chain remark and emit event
-func (this *SystemTx) RemarkWithEvent(remark []byte) Transaction {
+func (syt *SystemTx) RemarkWithEvent(remark []byte) Transaction {
 	call := syPallet.CallRemarkWithEvent{Remark: remark}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(syt.client, pallets.ToPayload(call))
 }
 
 type VectorTx struct {
 	client *Client
 }
 
-func (this *VectorTx) FulfillCall(functionId prim.H256, input []byte, output []byte, proof []byte, slot uint64) Transaction {
+func (vt *VectorTx) FulfillCall(functionId prim.H256, input []byte, output []byte, proof []byte, slot uint64) Transaction {
 	call := vcPallet.CallFulfillCall{FunctionId: functionId, Input: input, Output: output, Proof: proof, Slot: slot}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(vt.client, pallets.ToPayload(call))
 }
 
-func (this *VectorTx) Execute(slot uint64, addrMessage metadata.VectorMessage, accountProof []byte, storageProof []byte) Transaction {
+func (vt *VectorTx) Execute(slot uint64, addrMessage metadata.VectorMessage, accountProof []byte, storageProof []byte) Transaction {
 	call := vcPallet.CallExecute{Slot: slot, AddrMessage: addrMessage, AccountProof: accountProof, StorageProof: storageProof}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(vt.client, pallets.ToPayload(call))
 }
 
-func (this *VectorTx) SourceChainFroze(sourceChainId uint32, frozen bool) Transaction {
+func (vt *VectorTx) SourceChainFroze(sourceChainId uint32, frozen bool) Transaction {
 	call := vcPallet.CallSourceChainFroze{SourceChainId: sourceChainId, Frozen: frozen}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(vt.client, pallets.ToPayload(call))
 }
 
-func (this *VectorTx) SendMessage(message metadata.VectorMessage, To prim.H256, domain uint32) Transaction {
+func (vt *VectorTx) SendMessage(message metadata.VectorMessage, To prim.H256, domain uint32) Transaction {
 	call := vcPallet.CallSendMessage{Message: message, To: To, Domain: domain}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(vt.client, pallets.ToPayload(call))
 }
 
-func (this *VectorTx) SetPoseidonHash(period uint64, poseidonHash []byte) Transaction {
+func (vt *VectorTx) SetPoseidonHash(period uint64, poseidonHash []byte) Transaction {
 	call := vcPallet.CallSetPoseidonHash{Period: period, PoseidonHash: poseidonHash}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(vt.client, pallets.ToPayload(call))
 }
 
-func (this *VectorTx) SetBroadcaster(broadcasterDomain uint32, broadcaster prim.H256) Transaction {
+func (vt *VectorTx) SetBroadcaster(broadcasterDomain uint32, broadcaster prim.H256) Transaction {
 	call := vcPallet.CallSetBroadcaster{BroadcasterDomain: broadcasterDomain, Broadcaster: broadcaster}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(vt.client, pallets.ToPayload(call))
 }
 
-func (this *VectorTx) SetWhitelistedDomains(value []uint32) Transaction {
+func (vt *VectorTx) SetWhitelistedDomains(value []uint32) Transaction {
 	call := vcPallet.CallSetWhitelistedDomains{Value: value}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(vt.client, pallets.ToPayload(call))
 }
 
-func (this *VectorTx) SetConfiguration(value metadata.VectorConfiguration) Transaction {
+func (vt *VectorTx) SetConfiguration(value metadata.VectorConfiguration) Transaction {
 	call := vcPallet.CallSetConfiguration{Value: value}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(vt.client, pallets.ToPayload(call))
 }
 
-func (this *VectorTx) SetFunctionsIds(value prim.Option[metadata.Tuple2[prim.H256, prim.H256]]) Transaction {
+func (vt *VectorTx) SetFunctionsIds(value prim.Option[metadata.Tuple2[prim.H256, prim.H256]]) Transaction {
 	call := vcPallet.CallSetFunctionsIds{Value: value}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(vt.client, pallets.ToPayload(call))
 }
 
-func (this *VectorTx) SetStepVerificationKey(value prim.Option[[]byte]) Transaction {
+func (vt *VectorTx) SetStepVerificationKey(value prim.Option[[]byte]) Transaction {
 	call := vcPallet.CallSetStepVerificationKey{Value: value}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(vt.client, pallets.ToPayload(call))
 }
 
-func (this *VectorTx) SetRotateVerificationKey(value prim.Option[[]byte]) Transaction {
+func (vt *VectorTx) SetRotateVerificationKey(value prim.Option[[]byte]) Transaction {
 	call := vcPallet.CallSetRotateVerificationKey{Value: value}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(vt.client, pallets.ToPayload(call))
 }
 
-func (this *VectorTx) FailedSendMessageTxs(failedTxs []uint32) Transaction {
+func (vt *VectorTx) FailedSendMessageTxs(failedTxs []uint32) Transaction {
 	call := vcPallet.CallFailedSendMessageTxs{FailedTxs: failedTxs}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(vt.client, pallets.ToPayload(call))
 }
 
-func (this *VectorTx) SetUpdater(updater prim.H256) Transaction {
+func (vt *VectorTx) SetUpdater(updater prim.H256) Transaction {
 	call := vcPallet.CallSetUpdater{Updater: updater}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(vt.client, pallets.ToPayload(call))
 }
 
-func (this *VectorTx) Fulfill(proof []byte, publicValues []byte) Transaction {
+func (vt *VectorTx) Fulfill(proof []byte, publicValues []byte) Transaction {
 	call := vcPallet.CallFulfill{Proof: proof, PublicValues: publicValues}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(vt.client, pallets.ToPayload(call))
 }
 
-func (this *VectorTx) SetSp1VerificationKey(sp1Vk prim.H256) Transaction {
+func (vt *VectorTx) SetSp1VerificationKey(sp1Vk prim.H256) Transaction {
 	call := vcPallet.CallSetSp1VerificationKey{Sp1Vk: sp1Vk}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(vt.client, pallets.ToPayload(call))
 }
 
-func (this *VectorTx) SetSyncCommitteeHash(period uint64, Hash prim.H256) Transaction {
+func (vt *VectorTx) SetSyncCommitteeHash(period uint64, Hash prim.H256) Transaction {
 	call := vcPallet.CallSetSyncCommitteeHash{Period: period, Hash: Hash}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(vt.client, pallets.ToPayload(call))
 }
 
-func (this *VectorTx) EnableMock(value bool) Transaction {
+func (vt *VectorTx) EnableMock(value bool) Transaction {
 	call := vcPallet.CallEnableMock{Value: value}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(vt.client, pallets.ToPayload(call))
 }
 
-func (this *VectorTx) MockFulfill(publicValues []byte) Transaction {
+func (vt *VectorTx) MockFulfill(publicValues []byte) Transaction {
 	call := vcPallet.CallMockFulfill{PublicValues: publicValues}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(vt.client, pallets.ToPayload(call))
 }
 
 type SudoTx struct {
@@ -732,9 +732,9 @@ type SudoTx struct {
 }
 
 // Authenticates the sudo key and dispatches a function call with `Root` origin.
-func (this *SudoTx) Sudo(call prim.Call) Transaction {
+func (sdt *SudoTx) Sudo(call prim.Call) Transaction {
 	c := sdPallet.CallSudo{Call: call}
-	return NewTransaction(this.client, pallets.ToPayload(c))
+	return NewTransaction(sdt.client, pallets.ToPayload(c))
 }
 
 // Authenticates the sudo key and dispatches a function call with `Root` origin.
@@ -742,18 +742,18 @@ func (this *SudoTx) Sudo(call prim.Call) Transaction {
 // Sudo user to specify the weight of the call.
 //
 // The dispatch origin for this call must be _Signed_.
-func (this *SudoTx) SudoUncheckedWeight(call prim.Call) Transaction {
+func (sdt *SudoTx) SudoUncheckedWeight(call prim.Call) Transaction {
 	c := sdPallet.CallSudoUncheckedWeight{Call: call}
-	return NewTransaction(this.client, pallets.ToPayload(c))
+	return NewTransaction(sdt.client, pallets.ToPayload(c))
 }
 
 // Authenticates the sudo key and dispatches a function call with `Signed` origin from
 // a given account.
 //
 // The dispatch origin for this call must be _Signed_.
-func (this *SudoTx) SudoAs(who prim.MultiAddress, call prim.Call) Transaction {
+func (sdt *SudoTx) SudoAs(who prim.MultiAddress, call prim.Call) Transaction {
 	c := sdPallet.CallSudoAs{Who: who, Call: call}
-	return NewTransaction(this.client, pallets.ToPayload(c))
+	return NewTransaction(sdt.client, pallets.ToPayload(c))
 }
 
 type SessionTx struct {
@@ -763,9 +763,9 @@ type SessionTx struct {
 // Sets the session key(s) of the function caller to `keys`.
 // Allows an account to set its session key prior to becoming a validator.
 // This doesn't take effect until the next session.
-func (this *SessionTx) SetKeys(keys metadata.SessionKeys, proof []byte) Transaction {
+func (set *SessionTx) SetKeys(keys metadata.SessionKeys, proof []byte) Transaction {
 	call := sePallet.CallSetKeys{Keys: keys, Proof: proof}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(set.client, pallets.ToPayload(call))
 }
 
 // Removes any session key(s) of the function caller.
@@ -776,9 +776,9 @@ func (this *SessionTx) SetKeys(keys metadata.SessionKeys, proof []byte) Transact
 // convertible to a validator ID using the chain's typical addressing system (this usually
 // means being a controller account) or directly convertible into a validator ID (which
 // usually means being a stash account).
-func (this *SessionTx) PurgeKeys() Transaction {
+func (set *SessionTx) PurgeKeys() Transaction {
 	call := sePallet.CallPurgeKeys{}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(set.client, pallets.ToPayload(call))
 }
 
 type ProxyTx struct {
@@ -794,9 +794,9 @@ type ProxyTx struct {
 // - `Real`: The account that the proxy will make a call on behalf of.
 // - `ForceProxyType`: Specify the exact proxy type to be used and checked for this call.
 // - `Call`: The call to be made by the `real` account.
-func (this *ProxyTx) Proxy(real prim.MultiAddress, forceProxyType prim.Option[metadata.ProxyType], call prim.Call) Transaction {
+func (pt *ProxyTx) Proxy(real prim.MultiAddress, forceProxyType prim.Option[metadata.ProxyType], call prim.Call) Transaction {
 	c := pxPallet.CallProxy{Real: real, ForceProxyType: forceProxyType, Call: call}
-	return NewTransaction(this.client, pallets.ToPayload(c))
+	return NewTransaction(pt.client, pallets.ToPayload(c))
 }
 
 // Register a proxy account for the sender that is able to make calls on its behalf.
@@ -808,9 +808,9 @@ func (this *ProxyTx) Proxy(real prim.MultiAddress, forceProxyType prim.Option[me
 // - `ProxyType`: The permissions allowed for this proxy account.
 // - `Delay`: The announcement period required of the initial proxy. Will generally be
 // zero.
-func (this *ProxyTx) AddProxy(delegate prim.MultiAddress, proxyType metadata.ProxyType, delay uint32) Transaction {
+func (pt *ProxyTx) AddProxy(delegate prim.MultiAddress, proxyType metadata.ProxyType, delay uint32) Transaction {
 	call := pxPallet.CallAddProxy{Delegate: delegate, ProxyType: proxyType, Delay: delay}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(pt.client, pallets.ToPayload(call))
 }
 
 // Unregister a proxy account for the sender.
@@ -821,9 +821,9 @@ func (this *ProxyTx) AddProxy(delegate prim.MultiAddress, proxyType metadata.Pro
 // - `Delegate`: The account that the `caller` would like to remove as a proxy.
 // - `ProxyType`: The permissions currently enabled for the removed proxy account.
 // - `Delay`:  Will generally be zero.
-func (this *ProxyTx) RemoveProxy(delegate prim.MultiAddress, proxyType metadata.ProxyType, delay uint32) Transaction {
+func (pt *ProxyTx) RemoveProxy(delegate prim.MultiAddress, proxyType metadata.ProxyType, delay uint32) Transaction {
 	call := pxPallet.CallRemoveProxy{Delegate: delegate, ProxyType: proxyType, Delay: delay}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(pt.client, pallets.ToPayload(call))
 }
 
 // Unregister all proxy accounts for the sender.
@@ -832,9 +832,9 @@ func (this *ProxyTx) RemoveProxy(delegate prim.MultiAddress, proxyType metadata.
 //
 // WARNING: This may be called on accounts created by `pure`, however if done, then
 // the unreserved fees will be inaccessible. **All access to this account will be lost.**
-func (this *ProxyTx) RemoveProxies() Transaction {
+func (pt *ProxyTx) RemoveProxies() Transaction {
 	call := pxPallet.CallRemoveProxies{}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(pt.client, pallets.ToPayload(call))
 }
 
 // Spawn a fresh new account that is guaranteed to be otherwise inaccessible, and
@@ -855,9 +855,9 @@ func (this *ProxyTx) RemoveProxies() Transaction {
 // same sender, with the same parameters.
 //
 // Fails if there are insufficient funds to pay for deposit.
-func (this *ProxyTx) CreatePure(proxyType metadata.ProxyType, delay uint32, index uint16) Transaction {
+func (pt *ProxyTx) CreatePure(proxyType metadata.ProxyType, delay uint32, index uint16) Transaction {
 	call := pxPallet.CallCreatePure{ProxyType: proxyType, Delay: delay, Index: index}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(pt.client, pallets.ToPayload(call))
 }
 
 // Removes a previously spawned pure proxy.
@@ -876,9 +876,9 @@ func (this *ProxyTx) CreatePure(proxyType metadata.ProxyType, delay uint32, inde
 //
 // Fails with `NoPermission` in case the caller is not a previously created pure
 // account whose `pure` call has corresponding parameters.
-func (this *ProxyTx) KillPure(spawner prim.MultiAddress, proxyType metadata.ProxyType, index uint16, height uint32, extIndex uint32) Transaction {
+func (pt *ProxyTx) KillPure(spawner prim.MultiAddress, proxyType metadata.ProxyType, index uint16, height uint32, extIndex uint32) Transaction {
 	call := pxPallet.CallKillPure{Spawner: spawner, ProxyType: proxyType, Index: index, Height: height, ExtIndex: extIndex}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(pt.client, pallets.ToPayload(call))
 }
 
 // Publish the hash of a proxy-call that will be made in the future.
@@ -896,9 +896,9 @@ func (this *ProxyTx) KillPure(spawner prim.MultiAddress, proxyType metadata.Prox
 // Parameters:
 // - `Real`: The account that the proxy will make a call on behalf of.
 // - `CallHash`: The hash of the call to be made by the `real` account.
-func (this *ProxyTx) Announce(real prim.MultiAddress, callHash prim.H256) Transaction {
+func (pt *ProxyTx) Announce(real prim.MultiAddress, callHash prim.H256) Transaction {
 	call := pxPallet.CallAnnounce{Real: real, CallHash: callHash}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(pt.client, pallets.ToPayload(call))
 }
 
 // Remove a given announcement.
@@ -911,9 +911,9 @@ func (this *ProxyTx) Announce(real prim.MultiAddress, callHash prim.H256) Transa
 // Parameters:
 // - `Real`: The account that the proxy will make a call on behalf of.
 // - `CallHash`: The hash of the call to be made by the `real` account.
-func (this *ProxyTx) RemoveAnnouncement(real prim.MultiAddress, callHash prim.H256) Transaction {
+func (pt *ProxyTx) RemoveAnnouncement(real prim.MultiAddress, callHash prim.H256) Transaction {
 	call := pxPallet.CallRemoveAnnouncement{Real: real, CallHash: callHash}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(pt.client, pallets.ToPayload(call))
 }
 
 // Remove the given announcement of a delegate.
@@ -926,9 +926,9 @@ func (this *ProxyTx) RemoveAnnouncement(real prim.MultiAddress, callHash prim.H2
 // Parameters:
 // - `Delegate`: The account that previously announced the call.
 // - `CallHash`: The hash of the call to be made.
-func (this *ProxyTx) RejectAnnouncement(delegate prim.MultiAddress, callHash prim.H256) Transaction {
+func (pt *ProxyTx) RejectAnnouncement(delegate prim.MultiAddress, callHash prim.H256) Transaction {
 	call := pxPallet.CallRejectAnnouncement{Delegate: delegate, CallHash: callHash}
-	return NewTransaction(this.client, pallets.ToPayload(call))
+	return NewTransaction(pt.client, pallets.ToPayload(call))
 }
 
 // Dispatch the given `call` from an account that the sender is authorized for through
@@ -942,7 +942,7 @@ func (this *ProxyTx) RejectAnnouncement(delegate prim.MultiAddress, callHash pri
 // - `Real`: The account that the proxy will make a call on behalf of.
 // - `ForceProxyType`: Specify the exact proxy type to be used and checked for this call.
 // - `Call`: The call to be made by the `real` account.
-func (this *ProxyTx) ProxyAnnounced(delegate prim.MultiAddress, real prim.MultiAddress, forceProxyType prim.Option[metadata.ProxyType], call prim.Call) Transaction {
+func (pt *ProxyTx) ProxyAnnounced(delegate prim.MultiAddress, real prim.MultiAddress, forceProxyType prim.Option[metadata.ProxyType], call prim.Call) Transaction {
 	c := pxPallet.CallProxyAnnounced{Delegate: delegate, Real: real, ForceProxyType: forceProxyType, Call: call}
-	return NewTransaction(this.client, pallets.ToPayload(c))
+	return NewTransaction(pt.client, pallets.ToPayload(c))
 }

--- a/sdk/storage.go
+++ b/sdk/storage.go
@@ -9,14 +9,14 @@ type BlockStorage struct {
 	at     primitives.H256
 }
 
-func (this *BlockStorage) Fetch(storageEntryKey string) (primitives.Option[string], error) {
-	return this.client.Rpc.State.GetStorage(storageEntryKey, primitives.Some(this.at))
+func (b *BlockStorage) Fetch(storageEntryKey string) (primitives.Option[string], error) {
+	return b.client.Rpc.State.GetStorage(storageEntryKey, primitives.Some(b.at))
 }
 
-func (this *BlockStorage) FetchKeys(storageEntryKey string) ([]string, error) {
-	return this.client.Rpc.State.GetKeys(storageEntryKey, primitives.Some(this.at))
+func (b *BlockStorage) FetchKeys(storageEntryKey string) ([]string, error) {
+	return b.client.Rpc.State.GetKeys(storageEntryKey, primitives.Some(b.at))
 }
 
-func (this *BlockStorage) FetchKeysPaged(storageEntryKey string, count uint32, startKey primitives.Option[string]) ([]string, error) {
-	return this.client.Rpc.State.GetKeysPaged(storageEntryKey, count, startKey, primitives.Some(this.at))
+func (b *BlockStorage) FetchKeysPaged(storageEntryKey string, count uint32, startKey primitives.Option[string]) ([]string, error) {
+	return b.client.Rpc.State.GetKeysPaged(storageEntryKey, count, startKey, primitives.Some(b.at))
 }

--- a/sdk/transaction.go
+++ b/sdk/transaction.go
@@ -23,16 +23,16 @@ func NewTransaction(client *Client, payload metadata.Payload) Transaction {
 	}
 }
 
-func (this *Transaction) CallToHex() string {
-	return "0x" + prim.Encoder.Encode(this.Payload.Call)
+func (t *Transaction) CallToHex() string {
+	return "0x" + prim.Encoder.Encode(t.Payload.Call)
 }
 
-func (this *Transaction) ToHex(account subkey.KeyPair, options TransactionOptions) (string, error) {
-	extra, additional, _, err := options.ToPrimitive(this.client, account.SS58Address(42))
+func (t *Transaction) ToHex(account subkey.KeyPair, options TransactionOptions) (string, error) {
+	extra, additional, _, err := options.ToPrimitive(t.client, account.SS58Address(42))
 	if err != nil {
 		return "", err
 	}
-	tx, err := prim.CreateSigned(this.Payload.Call, extra, additional, account)
+	tx, err := prim.CreateSigned(t.Payload.Call, extra, additional, account)
 	if err != nil {
 		return "", err
 	}
@@ -45,8 +45,8 @@ func (this *Transaction) ToHex(account subkey.KeyPair, options TransactionOption
 // There is no guarantee that the transaction was executed at all. It might have been
 // dropped or discarded for various reasons. The caller is responsible for querying future
 // blocks in order to determine the execution status of that transaction.
-func (this *Transaction) Execute(account subkey.KeyPair, options TransactionOptions) (prim.H256, error) {
-	return TransactionSignAndSend(this.client, account, this.Payload, options)
+func (t *Transaction) Execute(account subkey.KeyPair, options TransactionOptions) (prim.H256, error) {
+	return TransactionSignAndSend(t.client, account, t.Payload, options)
 }
 
 // Transaction will be signed, sent, and watched
@@ -54,8 +54,8 @@ func (this *Transaction) Execute(account subkey.KeyPair, options TransactionOpti
 // for 2 more times using the same nonce and app id.
 //
 // Waits for finalization to finalize the transaction.
-func (this *Transaction) ExecuteAndWatchFinalization(account subkey.KeyPair, options TransactionOptions) (TransactionDetails, error) {
-	return TransactionSignSendWatch(this.client, account, this.Payload, Finalization, options)
+func (t *Transaction) ExecuteAndWatchFinalization(account subkey.KeyPair, options TransactionOptions) (TransactionDetails, error) {
+	return TransactionSignSendWatch(t.client, account, t.Payload, Finalization, options)
 }
 
 // Transaction will be signed, sent, and watched
@@ -64,34 +64,34 @@ func (this *Transaction) ExecuteAndWatchFinalization(account subkey.KeyPair, opt
 //
 // Waits for transaction inclusion. Most of the time you would want to call `ExecuteAndWatchFinalization` as
 // inclusion doesn't mean that the transaction will be in the canonical chain.
-func (this *Transaction) ExecuteAndWatchInclusion(account subkey.KeyPair, options TransactionOptions) (TransactionDetails, error) {
-	return TransactionSignSendWatch(this.client, account, this.Payload, Inclusion, options)
+func (t *Transaction) ExecuteAndWatchInclusion(account subkey.KeyPair, options TransactionOptions) (TransactionDetails, error) {
+	return TransactionSignSendWatch(t.client, account, t.Payload, Inclusion, options)
 }
 
-func (this *Transaction) PaymentQueryInfo(account subkey.KeyPair, options TransactionOptions) (metadata.RuntimeDispatchInfo, error) {
-	val, err := this.ToHex(account, options)
+func (t *Transaction) PaymentQueryInfo(account subkey.KeyPair, options TransactionOptions) (metadata.RuntimeDispatchInfo, error) {
+	val, err := t.ToHex(account, options)
 	if err != nil {
 		return metadata.RuntimeDispatchInfo{}, err
 	}
 
-	return this.client.Call.TransactionPaymentApi_queryInfo(val, prim.None[prim.H256]())
+	return t.client.Call.TransactionPaymentApi_queryInfo(val, prim.None[prim.H256]())
 }
 
-func (this *Transaction) PaymentQueryFeeDetails(account subkey.KeyPair, options TransactionOptions) (metadata.FeeDetails, error) {
-	val, err := this.ToHex(account, options)
+func (t *Transaction) PaymentQueryFeeDetails(account subkey.KeyPair, options TransactionOptions) (metadata.FeeDetails, error) {
+	val, err := t.ToHex(account, options)
 	if err != nil {
 		return metadata.FeeDetails{}, err
 	}
 
-	return this.client.Call.TransactionPaymentApi_queryFeeDetails(val, prim.None[prim.H256]())
+	return t.client.Call.TransactionPaymentApi_queryFeeDetails(val, prim.None[prim.H256]())
 }
 
-func (this *Transaction) PaymentQueryCallInfo() (metadata.RuntimeDispatchInfo, error) {
-	return this.client.Call.TransactionPaymentCallApi_queryCallInfo(this.CallToHex(), prim.None[prim.H256]())
+func (t *Transaction) PaymentQueryCallInfo() (metadata.RuntimeDispatchInfo, error) {
+	return t.client.Call.TransactionPaymentCallApi_queryCallInfo(t.CallToHex(), prim.None[prim.H256]())
 }
 
-func (this *Transaction) PaymentQueryCallFeeDetails() (metadata.FeeDetails, error) {
-	return this.client.Call.TransactionPaymentCallApi_queryCallFeeDetails(this.CallToHex(), prim.None[prim.H256]())
+func (t *Transaction) PaymentQueryCallFeeDetails() (metadata.FeeDetails, error) {
+	return t.client.Call.TransactionPaymentCallApi_queryCallFeeDetails(t.CallToHex(), prim.None[prim.H256]())
 }
 
 type TransactionDetails struct {
@@ -106,8 +106,8 @@ type TransactionDetails struct {
 // Returns None if there was no way to determine the
 // success status of a transaction. Otherwise it returns
 // true or false.
-func (this *TransactionDetails) IsSuccessful() prim.Option[bool] {
-	events := this.Events.Unwrap()
+func (t *TransactionDetails) IsSuccessful() prim.Option[bool] {
+	events := t.Events.Unwrap()
 
 	extFailedEvent := syPallet.EventExtrinsicFailed{}
 	extSuccessEvent := syPallet.EventExtrinsicSuccess{}

--- a/sdk/transaction_options.go
+++ b/sdk/transaction_options.go
@@ -23,27 +23,27 @@ func NewTransactionOptions() TransactionOptions {
 	}
 }
 
-func (this TransactionOptions) WithAppId(value uint32) TransactionOptions {
-	this.AppId = prim.Some(value)
-	return this
+func (t TransactionOptions) WithAppId(value uint32) TransactionOptions {
+	t.AppId = prim.Some(value)
+	return t
 }
 
-func (this TransactionOptions) WithNonce(value uint32) TransactionOptions {
-	this.Nonce = prim.Some(value)
-	return this
+func (t TransactionOptions) WithNonce(value uint32) TransactionOptions {
+	t.Nonce = prim.Some(value)
+	return t
 }
 
-func (this TransactionOptions) WithMortality(value uint32) TransactionOptions {
-	this.Mortality = prim.Some(value)
-	return this
+func (t TransactionOptions) WithMortality(value uint32) TransactionOptions {
+	t.Mortality = prim.Some(value)
+	return t
 }
 
-func (this TransactionOptions) WithTip(value metadata.Balance) TransactionOptions {
-	this.Tip = prim.Some(value)
-	return this
+func (t TransactionOptions) WithTip(value metadata.Balance) TransactionOptions {
+	t.Tip = prim.Some(value)
+	return t
 }
 
-func (this *TransactionOptions) ToPrimitive(client *Client, accountAddress string) (prim.Extra, prim.Additional, uint32, error) {
+func (t *TransactionOptions) ToPrimitive(client *Client, accountAddress string) (prim.Extra, prim.Additional, uint32, error) {
 	forkHash, err := client.Rpc.Chain.GetFinalizedHead()
 	if err != nil {
 		return prim.Extra{}, prim.Additional{}, 0, err
@@ -62,17 +62,17 @@ func (this *TransactionOptions) ToPrimitive(client *Client, accountAddress strin
 	}
 
 	extra := prim.Extra{}
-	extra.AppId = this.AppId.UnwrapOr(uint32(0))
-	extra.Tip = this.Tip.UnwrapOr(metadata.Balance{Value: uint128.Zero}).Value
-	if this.Nonce.IsNone() {
+	extra.AppId = t.AppId.UnwrapOr(uint32(0))
+	extra.Tip = t.Tip.UnwrapOr(metadata.Balance{Value: uint128.Zero}).Value
+	if t.Nonce.IsNone() {
 		extra.Nonce, err = client.Rpc.System.AccountNextIndex(accountAddress)
 		if err != nil {
 			return prim.Extra{}, prim.Additional{}, 0, err
 		}
 	} else {
-		extra.Nonce = this.Nonce.Unwrap()
+		extra.Nonce = t.Nonce.Unwrap()
 	}
-	extra.Era = prim.NewEra(uint64(this.Mortality.UnwrapOr(32)), uint64(forkBlockNumber))
+	extra.Era = prim.NewEra(uint64(t.Mortality.UnwrapOr(32)), uint64(forkBlockNumber))
 
 	return extra, additional, forkBlockNumber, nil
 }


### PR DESCRIPTION
### Summary

This PR refactors the method receivers across the codebase to follow Go's idiomatic naming conventions.

### What was changed

- Renamed method receivers from `this` to short, meaningful names like `bt`, `tx`, or `btx` depending on the struct.
- No logic is changed, purely cosmetic/code quality improvement.

### Why

- `this` is not an idiomatic receiver name in Go. It is typically used in other languages like Java or JavaScript.
- According to [Effective Go](https://golang.org/doc/effective_go#methods), method receivers should be short and related to the struct name.
- Improves readability and consistency with common Go practices.

### Notes

No functional changes. All existing functionality remains the same.